### PR TITLE
wip: add markers to custom layers & sources

### DIFF
--- a/lib/export-control.ts
+++ b/lib/export-control.ts
@@ -1,4 +1,4 @@
-import { ControlPosition, IControl, Map as MaplibreMap } from 'maplibre-gl';
+import { ControlPosition, IControl, Map as MaplibreMap, Marker } from 'maplibre-gl';
 import CrosshairManager from './crosshair-manager';
 import PrintableAreaManager from './printable-area-manager';
 import {
@@ -22,6 +22,7 @@ type Options = {
   Local?: 'en' | 'fr' | 'fi' | 'sv';
   AllowedSizes?: ('A2'|'A3'|'A4'|'A5'|'A6'|'B2'|'B3'|'B4'|'B5'|'B6')[];
   Filename?: string;
+  Markers?: Marker[];
 }
 
 /**
@@ -50,7 +51,8 @@ export default class MaplibreExportControl implements IControl {
       PrintableArea: false,
       Local: 'en',
       AllowedSizes: Object.keys(Size) as ('A2'|'A3'|'A4'|'A5'|'A6'|'B2'|'B3'|'B4'|'B5'|'B6')[],
-      Filename: 'map'
+      Filename: 'map',
+      Markers: [],
     }
 
     constructor(options: Options) {
@@ -153,7 +155,8 @@ export default class MaplibreExportControl implements IControl {
           Number(dpiType.value),
           formatType.value,
           Unit.mm,
-          this.options.Filename
+          this.options.Filename,
+          this.options.Markers ?? [],
         );
         mapGenerator.generate();
       });

--- a/lib/map-generator.ts
+++ b/lib/map-generator.ts
@@ -29,7 +29,7 @@
 
 import { jsPDF } from 'jspdf';
 import { saveAs } from 'file-saver';
-import { Map as MaplibreMap } from 'maplibre-gl';
+import { Map as MaplibreMap, Marker } from 'maplibre-gl';
 import 'js-loading-overlay';
 import { fabric } from 'fabric';
 
@@ -84,7 +84,6 @@ export const DPI = {
 type DPI = typeof DPI[keyof typeof DPI];
 
 export default class MapGenerator {
-
   private width: number;
 
   private height: number;
@@ -103,7 +102,8 @@ export default class MapGenerator {
     private dpi: number = 300,
     private format:string = Format.PNG.toString(),
     private unit: Unit = Unit.mm,
-    private fileName: string = 'map'
+    private fileName: string = 'map',
+    private markers: Marker[]
   ) {
     this.width = size[0];
     this.height = size[1];
@@ -160,6 +160,29 @@ export default class MapGenerator {
         });
       });
     }
+
+    // Add markers to the layers
+    this.markers.forEach((marker, index) => {
+      this.map.addSource(`point${index}`, {
+        type: 'geojson',
+        data: {
+          type: 'Point',
+          coordinates: [marker.getLngLat().lng, marker.getLngLat().lat],
+        },
+      });
+
+      this.map.addLayer({
+        id: `point${index}`,
+        source: `point${index}`,
+        type: 'circle',
+        paint: {
+          'circle-radius': 8,
+          'circle-color': 'red',
+          'circle-stroke-width': 1,
+          'circle-blur': 0.5,
+        },
+      });
+    });
 
     // Render map
     const renderMap = new MaplibreMap({


### PR DESCRIPTION
**THIS IS A WORK IN PROGRESS AND IS NOT FULLY FUNCTIONAL.** _Please, feel free to request changes or directly edit the code._

## Description

Adds a new optional `Markers` property to the constructor to allow the plugin to convert `maplibregl.Marker[]` to custom layers and then print them.

## Type of Pull Request
<!-- ignore-task-list-start -->
- [x] Adding a feature
- [x] Fixing a bug (see #16)
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings
<!-- ignore-task-list-start -->
- [x] Code is up-to-date with the `main` branch
- [x] No lint errors after `yarn run lint`
- [ ] Make sure all the exsiting features working well
<!-- ignore-task-list-end -->
