### PR TITLE
fix:  bug of export PDF of correct size

### DIFF
--- a/.changeset/slow-donuts-speak.md
+++ b/.changeset/slow-donuts-speak.md
@@ -1,0 +1,5 @@
+---
+"@watergis/maplibre-gl-export": patch
+---
+
+fix: fixed the bug of export PDF of A3 size spondered by @PivnoyBaronDmitry through the PR of https://github.com/watergis/mapbox-gl-export/pull/48

--- a/packages/maplibre-gl-export/src/lib/map-generator.ts
+++ b/packages/maplibre-gl-export/src/lib/map-generator.ts
@@ -283,7 +283,8 @@ export default class MapGenerator {
 		const pdf = new jsPDF({
 			orientation: this.width > this.height ? 'l' : 'p',
 			unit: this.unit,
-			compress: true
+			compress: true,
+			format: [this.width, this.height]
 		});
 
 		pdf.addImage(


### PR DESCRIPTION
fixes #7 

## Description

[Please describe what you changed briefly.](fix: fixed the bug of export PDF of A3 size spondered by @PivnoyBaronDmitry through the PR of https://github.com/watergis/mapbox-gl-export/pull/48)

## Type of Pull Request
<!-- ignore-task-list-start -->
- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings
<!-- ignore-task-list-start -->
- [x] Code is up-to-date with the `main` branch
- [x] No lint errors after `pnpm lint`
- [x] Make sure all the exsiting features working well
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/watergis/maplibre-gl-export/tree/master/.github/CONTRIBUTING.md) for more details.
