### PR TITLE
Update load map images

### DIFF
--- a/packages/maplibre-gl-export/src/lib/map-generator.ts
+++ b/packages/maplibre-gl-export/src/lib/map-generator.ts
@@ -196,14 +196,21 @@ export default class MapGenerator {
 			// @ts-ignore
 			transformRequest: (this.map as unknown)._requestManager._transformRequestFn
 		});
-
-		// comment this statement because an error is occured since maplibre v3. images[key].data has no value (null)
-		// it looks working well in my style. let's see how it works without this code
-		// the below code was added by https://github.com/watergis/maplibre-gl-export/pull/18.
-		// const images = (this.map.style.imageManager || {}).images || [];
-		// Object.keys(images).forEach((key) => {
-		// 	renderMap.addImage(key, images[key].data);
-		// });
+		
+		// Attempt to load images that were loaded in source map using addImage(). This does not load sprite images.
+		// Modification based on https://github.com/watergis/maplibre-gl-export/pull/18
+		const images = (this.map.style.imageManager || {}).images || [];
+		for (const key of Object.keys(images)) {
+			const _image = images[key];
+			
+			if (_image?.data) {				
+				try {
+					renderMap.addImage(key, _image?.data);
+				} catch(err) {
+					console.error(`Error adding image: ${err.message}`);
+				}
+			}
+		}
 
 		renderMap.once('idle', () => {
 			const canvas = renderMap.getCanvas();


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

Please describe what you changed briefly.

Fix adding images to the map as per https://github.com/watergis/maplibre-gl-export/pull/18

Problem: Images added to the map are not exported in the output image. 

Solution: In the images loop, check for image?.data property. At this point, you may also access the spriteData.context.canvas object. However, for simplicity, this PR does not handle sprite images. It only fixes adding images with the images?.data property. 

I use try catch so it does not prevent subsequent images from loading.

## Type of Pull Request
<!-- ignore-task-list-start -->
- [ ] Adding a feature
- [ x] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings
<!-- ignore-task-list-start -->
- [x ] Code is up-to-date with the `main` branch
- [ x] No lint errors after `pnpm lint`
- [ x] Make sure all the exsiting features working well
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/watergis/maplibre-gl-export/tree/master/.github/CONTRIBUTING.md) for more details.
