### PR TITLE
feat: apply maplibre terrain mode for image exporting if it is used.

### DIFF
--- a/.changeset/weak-mice-unite.md
+++ b/.changeset/weak-mice-unite.md
@@ -1,0 +1,5 @@
+---
+"@watergis/maplibre-gl-export": minor
+---
+
+feat: apply maplibre terrain mode for image exporting if it is used.

--- a/packages/maplibre-gl-export/index.ts
+++ b/packages/maplibre-gl-export/index.ts
@@ -1,4 +1,4 @@
-import maplibregl, { Map, NavigationControl } from 'maplibre-gl';
+import maplibregl, { Map, NavigationControl, TerrainControl } from 'maplibre-gl';
 import 'maplibre-gl/dist/maplibre-gl.css';
 import { MaplibreExportControl, Size, PageOrientation, Format, DPI } from './src/lib/index';
 import './src/scss/maplibre-gl-export.scss';
@@ -9,12 +9,18 @@ maplibregl.addProtocol('pmtiles', protocol.tile);
 
 const map = new Map({
 	container: 'map',
-	style: 'https://narwassco.github.io/mapbox-stylefiles/unvt/style.json',
-	center: [35.87063, -1.08551],
-	zoom: 12,
+	// narok vector style
+	// style: 'https://narwassco.github.io/mapbox-stylefiles/unvt/style.json',
+	// center: [35.87063, -1.08551],
+	// zoom: 12,
+	// terrain testing with Bing aerial
+	style: 'https://unpkg.com/@undp-data/style@latest/dist/aerialstyle.json',
+	center: [0, 0],
+	zoom: 1,
 	hash: true
 });
-map.addControl(new NavigationControl({}), 'top-right');
+
+map.addControl(new NavigationControl({ visualizePitch: true }), 'top-right');
 map.addControl(
 	new MaplibreExportControl({
 		PageSize: Size.A3,
@@ -27,3 +33,17 @@ map.addControl(
 	}),
 	'top-right'
 );
+
+map.once('load', () => {
+	if (map.getSource('terrarium')) {
+		map.addControl(
+			new TerrainControl({
+				source: 'terrarium',
+				exaggeration: 1
+			}),
+			'top-right'
+		);
+
+		map.setMaxPitch(85);
+	}
+});

--- a/packages/maplibre-gl-export/src/lib/map-generator-base.ts
+++ b/packages/maplibre-gl-export/src/lib/map-generator-base.ts
@@ -79,6 +79,10 @@ export abstract class MapGeneratorBase {
 		style: StyleSpecification | mapboxgl.Style
 	): MaplibreMap | MapboxMap;
 
+	protected renderMapPost(renderMap: MaplibreMap | MapboxMap) {
+		return renderMap;
+	}
+
 	/**
 	 * Generate and download Map image
 	 */
@@ -136,9 +140,10 @@ export abstract class MapGeneratorBase {
 		}
 
 		// Render map
-		const renderMap = this.getRenderedMap(container, style);
+		let renderMap = this.getRenderedMap(container, style);
 
 		renderMap.once('idle', () => {
+			renderMap = this.renderMapPost(renderMap);
 			const canvas = renderMap.getCanvas();
 			const fileName = `${this.fileName}.${this_.format}`;
 			switch (this_.format) {

--- a/packages/maplibre-gl-export/src/lib/map-generator.ts
+++ b/packages/maplibre-gl-export/src/lib/map-generator.ts
@@ -26,7 +26,7 @@ export default class MapGenerator extends MapGeneratorBase {
 
 	protected getRenderedMap(container: HTMLElement, style: StyleSpecification) {
 		// Render map
-		const renderMap = new MaplibreMap({
+		const renderMap: MaplibreMap = new MaplibreMap({
 			container,
 			style,
 			center: this.map.getCenter(),
@@ -43,6 +43,13 @@ export default class MapGenerator extends MapGeneratorBase {
 			transformRequest: (this.map as unknown)._requestManager._transformRequestFn
 		});
 
+		const terrain = (this.map as MaplibreMap).getTerrain();
+		if (terrain) {
+			// if terrain is enabled, restore pitch correctly
+			renderMap.setMaxPitch(85);
+			renderMap.setPitch(this.map.getPitch());
+		}
+
 		// comment this statement because an error is occured since maplibre v3. images[key].data has no value (null)
 		// it looks working well in my style. let's see how it works without this code
 		// the below code was added by https://github.com/watergis/maplibre-gl-export/pull/18.
@@ -50,6 +57,19 @@ export default class MapGenerator extends MapGeneratorBase {
 		// Object.keys(images).forEach((key) => {
 		// 	renderMap.addImage(key, images[key].data);
 		// });
+
+		return renderMap;
+	}
+
+	protected renderMapPost(renderMap: MaplibreMap) {
+		const terrain = (this.map as MaplibreMap).getTerrain();
+		if (terrain) {
+			// if terrain is enabled, set terrain for rendered map object
+			renderMap.setTerrain({
+				source: terrain.source,
+				exaggeration: terrain.exaggeration
+			});
+		}
 
 		return renderMap;
 	}

--- a/sites/demo/src/routes/(demo)/mapbox/+page.svelte
+++ b/sites/demo/src/routes/(demo)/mapbox/+page.svelte
@@ -40,8 +40,6 @@
 			Local: $languageStore
 		});
 
-		($mapStore as Map).addControl(new NavigationControl(), 'bottom-right');
-
 		$mapStore.addControl(exportControl, 'top-right');
 	};
 
@@ -56,6 +54,8 @@
 			hash: true,
 			accessToken: PUBLIC_MAPBOX_ACCESSTOKEN
 		});
+
+		($mapStore as Map).addControl(new NavigationControl(), 'bottom-right');
 
 		initExportControl();
 

--- a/sites/demo/src/routes/(demo)/maplibre/+page.svelte
+++ b/sites/demo/src/routes/(demo)/maplibre/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { addProtocol, Map, NavigationControl } from 'maplibre-gl';
+	import { addProtocol, Map, NavigationControl, TerrainControl } from 'maplibre-gl';
 	import {
 		MaplibreExportControl,
 		Size,
@@ -49,13 +49,32 @@
 
 		$mapStore = new Map({
 			container: 'map',
-			style: 'https://narwassco.github.io/mapbox-stylefiles/unvt/style.json',
-			center: [35.87063, -1.08551],
-			zoom: 12,
+			// narok vector style
+			// style: 'https://narwassco.github.io/mapbox-stylefiles/unvt/style.json',
+			// center: [35.87063, -1.08551],
+			// zoom: 12,
+			// terrain testing with Bing aerial
+			style: 'https://unpkg.com/@undp-data/style@latest/dist/aerialstyle.json',
+			center: [0, 0],
+			zoom: 1,
 			hash: true
 		});
 
-		$mapStore.addControl(new NavigationControl(), 'bottom-right');
+		$mapStore.addControl(new NavigationControl({ visualizePitch: true }), 'bottom-right');
+
+		$mapStore.once('load', () => {
+			if ($mapStore.getSource('terrarium')) {
+				($mapStore as Map).addControl(
+					new TerrainControl({
+						source: 'terrarium',
+						exaggeration: 1
+					}),
+					'bottom-right'
+				);
+
+				$mapStore.setMaxPitch(85);
+			}
+		});
 
 		initExportControl();
 


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

closes #22

@ubukawa I finally solve the issue of applying maplibre terrain for the export plugin. I think it looks working quite well.

- in browser
![image](https://github.com/watergis/maplibre-gl-export/assets/2639701/9bc1ef54-1cd2-4d81-95cd-c8481415d6fa)

- image after exported
![Map (3)](https://github.com/watergis/maplibre-gl-export/assets/2639701/bba9bfec-6ed2-4a9a-90c7-0f78ddd3c416)

## Type of Pull Request
<!-- ignore-task-list-start -->
- [x] Adding a feature
- [ ] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings
<!-- ignore-task-list-start -->
- [x] Code is up-to-date with the `main` branch
- [x] No lint errors after `pnpm lint`
- [x] Make sure all the exsiting features working well
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/watergis/maplibre-gl-export/tree/master/.github/CONTRIBUTING.md) for more details.
