### PR TITLE
feat: export markers as circle layer if they are added to map object.

### DIFF
--- a/.changeset/grumpy-clouds-rescue.md
+++ b/.changeset/grumpy-clouds-rescue.md
@@ -1,0 +1,15 @@
+---
+"@watergis/maplibre-gl-export": minor
+"@watergis/mapbox-gl-export": minor
+---
+
+feat: export markers as circle layer if they are added to map object. `markerCirclePaint` option is added to allow changing default circle style for marker. The default marker style is:
+
+```json
+{
+  "circle-radius": 8,
+  "circle-color": "red",
+  "circle-stroke-width": 1,
+  "circle-stroke-color": "black"
+}
+```

--- a/packages/mapbox-gl-export/README.md
+++ b/packages/mapbox-gl-export/README.md
@@ -132,6 +132,17 @@ You can specify default option as follows.
 - Filename
   - file name template, file part
   - default `map` for i.e `map.pdf`
+- markerCirclePaint: The plugin will convert marker SVG to circle layer to be exported.
+  - Circle paint property setting. As default, the following paint setting will be applied
+
+```json
+{
+  "circle-radius": 8,
+  "circle-color": "red",
+  "circle-stroke-width": 1,
+  "circle-stroke-color": "black"
+}
+```
 
 ## Attribution
 

--- a/packages/mapbox-gl-export/index.ts
+++ b/packages/mapbox-gl-export/index.ts
@@ -23,3 +23,5 @@ map.addControl(
 	}),
 	'top-right'
 );
+
+new mapboxgl.Marker().setLngLat([37.30467, -0.15943]).addTo(map);

--- a/packages/mapbox-gl-export/src/lib/export-control.ts
+++ b/packages/mapbox-gl-export/src/lib/export-control.ts
@@ -38,6 +38,7 @@ export default class MapboxExportControl extends MaplibreExportControl implement
 			format,
 			unit,
 			filename,
+			this.options.markerCirclePaint,
 			this.accessToken
 		);
 		mapGenerator.generate();

--- a/packages/mapbox-gl-export/src/lib/map-generator.ts
+++ b/packages/mapbox-gl-export/src/lib/map-generator.ts
@@ -1,6 +1,7 @@
 import mapboxgl, { accessToken, Map as MapboxMap } from 'mapbox-gl';
 import 'js-loading-overlay';
 import {
+	defaultMarkerCirclePaint,
 	DPIType,
 	Format,
 	FormatType,
@@ -30,9 +31,10 @@ export default class MapGenerator extends MapGeneratorBase {
 		format: FormatType = Format.PNG,
 		unit: UnitType = Unit.mm,
 		fileName = 'map',
+		markerCirclePaint = defaultMarkerCirclePaint,
 		accesstoken?: string
 	) {
-		super(map, size, dpi, format, unit, fileName);
+		super(map, size, dpi, format, unit, fileName, 'mapboxgl-marker', markerCirclePaint);
 		this.accesstoken = accesstoken;
 	}
 

--- a/packages/maplibre-gl-export/README.md
+++ b/packages/maplibre-gl-export/README.md
@@ -103,6 +103,17 @@ You can specify default option as follows.
 - Filename
   - file name template, file part
   - default `map` for i.e `map.pdf`
+- markerCirclePaint: The plugin will convert marker SVG to circle layer to be exported.
+  - Circle paint property setting. As default, the following paint setting will be applied
+
+```json
+{
+  "circle-radius": 8,
+  "circle-color": "red",
+  "circle-stroke-width": 1,
+  "circle-stroke-color": "black"
+}
+```
 
 ## Attribution
 

--- a/packages/maplibre-gl-export/index.ts
+++ b/packages/maplibre-gl-export/index.ts
@@ -35,6 +35,8 @@ map.addControl(
 );
 
 map.once('load', () => {
+	new maplibregl.Marker().setLngLat([37.30467, -0.15943]).addTo(map);
+
 	if (map.getSource('terrarium')) {
 		map.addControl(
 			new TerrainControl({

--- a/packages/maplibre-gl-export/src/lib/export-control.ts
+++ b/packages/maplibre-gl-export/src/lib/export-control.ts
@@ -18,6 +18,7 @@ import {
 	UnitType,
 	type Language
 } from './interfaces';
+import { defaultMarkerCirclePaint } from './map-generator-base';
 
 /**
  * Maplibre GL Export Control.
@@ -57,7 +58,8 @@ export default class MaplibreExportControl implements IControl {
 			| 'B5'
 			| 'B6'
 		)[],
-		Filename: 'map'
+		Filename: 'map',
+		markerCirclePaint: defaultMarkerCirclePaint
 	};
 
 	protected MAPLIB_CSS_PREFIX: string = 'maplibregl';
@@ -192,7 +194,15 @@ export default class MaplibreExportControl implements IControl {
 		unit: UnitType,
 		filename?: string
 	) {
-		const mapGenerator = new MapGenerator(map as MaplibreMap, size, dpi, format, unit, filename);
+		const mapGenerator = new MapGenerator(
+			map as MaplibreMap,
+			size,
+			dpi,
+			format,
+			unit,
+			filename,
+			this.options.markerCirclePaint
+		);
 		mapGenerator.generate();
 	}
 

--- a/packages/maplibre-gl-export/src/lib/interfaces/ControlOptions.ts
+++ b/packages/maplibre-gl-export/src/lib/interfaces/ControlOptions.ts
@@ -1,3 +1,4 @@
+import { CirclePaint } from 'mapbox-gl';
 import { FormatType } from './Format';
 import { Language } from './Language';
 import { PageOrientationType } from './PageOrientation';
@@ -13,4 +14,5 @@ export interface ControlOptions {
 	Local?: Language;
 	AllowedSizes?: ('LETTER' | 'A2' | 'A3' | 'A4' | 'A5' | 'A6' | 'B2' | 'B3' | 'B4' | 'B5' | 'B6')[];
 	Filename?: string;
+	markerCirclePaint?: CirclePaint;
 }

--- a/packages/maplibre-gl-export/src/lib/map-generator-base.ts
+++ b/packages/maplibre-gl-export/src/lib/map-generator-base.ts
@@ -106,7 +106,7 @@ export abstract class MapGeneratorBase {
 
 	protected renderMarkers(renderMap: MaplibreMap | MapboxMap) {
 		const markers = this.getMarkers();
-		for (var i = 0; i < markers.length; i++) {
+		for (let i = 0; i < markers.length; i++) {
 			const marker = markers.item(i);
 			if (!marker) continue;
 			const style = marker.getAttribute('style');

--- a/packages/maplibre-gl-export/src/lib/map-generator-base.ts
+++ b/packages/maplibre-gl-export/src/lib/map-generator-base.ts
@@ -29,9 +29,16 @@
 
 import { jsPDF } from 'jspdf';
 import { Map as MaplibreMap, StyleSpecification } from 'maplibre-gl';
-import { Map as MapboxMap } from 'mapbox-gl';
+import { CirclePaint, Map as MapboxMap } from 'mapbox-gl';
 import 'js-loading-overlay';
 import { DPIType, Format, FormatType, Size, SizeType, Unit, UnitType } from './interfaces';
+
+export const defaultMarkerCirclePaint: CirclePaint = {
+	'circle-radius': 8,
+	'circle-color': 'red',
+	'circle-stroke-width': 1,
+	'circle-stroke-color': 'black'
+};
 
 export abstract class MapGeneratorBase {
 	protected map: MaplibreMap | MapboxMap;
@@ -48,6 +55,12 @@ export abstract class MapGeneratorBase {
 
 	protected fileName: string;
 
+	protected markerClassName: string;
+
+	protected markerImageName = 'export-plugin-marker';
+
+	protected markerCirclePaint: CirclePaint;
+
 	/**
 	 * Constructor
 	 * @param map MaplibreMap object
@@ -63,7 +76,9 @@ export abstract class MapGeneratorBase {
 		dpi: DPIType = 300,
 		format: FormatType = Format.PNG,
 		unit: UnitType = Unit.mm,
-		fileName = 'map'
+		fileName = 'map',
+		markerClassName = 'maplibregl-marker',
+		markerCirclePaint = defaultMarkerCirclePaint
 	) {
 		this.map = map;
 		this.width = size[0];
@@ -72,6 +87,8 @@ export abstract class MapGeneratorBase {
 		this.format = format;
 		this.unit = unit;
 		this.fileName = fileName;
+		this.markerClassName = markerClassName;
+		this.markerCirclePaint = markerCirclePaint;
 	}
 
 	protected abstract getRenderedMap(
@@ -80,6 +97,44 @@ export abstract class MapGeneratorBase {
 	): MaplibreMap | MapboxMap;
 
 	protected renderMapPost(renderMap: MaplibreMap | MapboxMap) {
+		return renderMap;
+	}
+
+	private getMarkers() {
+		return this.map.getCanvasContainer().getElementsByClassName(this.markerClassName);
+	}
+
+	protected renderMarkers(renderMap: MaplibreMap | MapboxMap) {
+		const markers = this.getMarkers();
+		for (var i = 0; i < markers.length; i++) {
+			const marker = markers.item(i);
+			if (!marker) continue;
+			const style = marker.getAttribute('style');
+			if (!style) continue;
+			const translateRegex = /translate\(([^,]+)px,\s*([^,]+)px\)/;
+			const match = style.match(translateRegex);
+			if (!match) continue;
+			const translateX = parseInt(match[1]);
+			const translateY = parseInt(match[2]);
+
+			const lngLat = this.map.unproject([translateX, translateY]);
+
+			const markerId = `point${i}`;
+			renderMap.addSource(markerId, {
+				type: 'geojson',
+				data: {
+					type: 'Point',
+					coordinates: [lngLat.lng, lngLat.lat]
+				}
+			});
+
+			(renderMap as MapboxMap).addLayer({
+				id: markerId,
+				source: markerId,
+				type: 'circle',
+				paint: this.markerCirclePaint
+			});
+		}
 		return renderMap;
 	}
 
@@ -144,39 +199,56 @@ export abstract class MapGeneratorBase {
 
 		renderMap.once('idle', () => {
 			renderMap = this.renderMapPost(renderMap);
-			const canvas = renderMap.getCanvas();
-			const fileName = `${this.fileName}.${this_.format}`;
-			switch (this_.format) {
-				case Format.PNG:
-					this_.toPNG(canvas, fileName);
-					break;
-				case Format.JPEG:
-					this_.toJPEG(canvas, fileName);
-					break;
-				case Format.PDF:
-					this_.toPDF(renderMap, fileName);
-					break;
-				case Format.SVG:
-					this_.toSVG(canvas, fileName);
-					break;
-				default:
-					console.error(`Invalid file format: ${this_.format}`);
-					break;
+			const markers = this.getMarkers();
+			if (markers.length === 0) {
+				this.exportImage(renderMap, hidden, actualPixelRatio);
+			} else {
+				renderMap = this.renderMarkers(renderMap);
+				renderMap.once('idle', () => {
+					this.exportImage(renderMap, hidden, actualPixelRatio);
+				});
 			}
-
-			renderMap.remove();
-			hidden.parentNode?.removeChild(hidden);
-			Object.defineProperty(window, 'devicePixelRatio', {
-				get() {
-					return actualPixelRatio;
-				}
-			});
-			hidden.remove();
-
-			// eslint-disable-next-line
-			// @ts-ignore
-			JsLoadingOverlay.hide();
 		});
+	}
+
+	private exportImage(
+		renderMap: MaplibreMap | MapboxMap,
+		hiddenDiv: HTMLElement,
+		actualPixelRatio: number
+	) {
+		const canvas = renderMap.getCanvas();
+
+		const fileName = `${this.fileName}.${this.format}`;
+		switch (this.format) {
+			case Format.PNG:
+				this.toPNG(canvas, fileName);
+				break;
+			case Format.JPEG:
+				this.toJPEG(canvas, fileName);
+				break;
+			case Format.PDF:
+				this.toPDF(renderMap, fileName);
+				break;
+			case Format.SVG:
+				this.toSVG(canvas, fileName);
+				break;
+			default:
+				console.error(`Invalid file format: ${this.format}`);
+				break;
+		}
+
+		renderMap.remove();
+		hiddenDiv.parentNode?.removeChild(hiddenDiv);
+		Object.defineProperty(window, 'devicePixelRatio', {
+			get() {
+				return actualPixelRatio;
+			}
+		});
+		hiddenDiv.remove();
+
+		// eslint-disable-next-line
+		// @ts-ignore
+		JsLoadingOverlay.hide();
 	}
 
 	/**

--- a/packages/maplibre-gl-export/src/lib/map-generator.ts
+++ b/packages/maplibre-gl-export/src/lib/map-generator.ts
@@ -1,7 +1,7 @@
 import { Map as MaplibreMap, StyleSpecification } from 'maplibre-gl';
 import 'js-loading-overlay';
 import { DPIType, Format, FormatType, Size, SizeType, Unit, UnitType } from './interfaces';
-import { MapGeneratorBase } from './map-generator-base';
+import { MapGeneratorBase, defaultMarkerCirclePaint } from './map-generator-base';
 
 export default class MapGenerator extends MapGeneratorBase {
 	/**
@@ -19,9 +19,10 @@ export default class MapGenerator extends MapGeneratorBase {
 		dpi: DPIType = 300,
 		format: FormatType = Format.PNG,
 		unit: UnitType = Unit.mm,
-		fileName = 'map'
+		fileName = 'map',
+		markerCirclePaint = defaultMarkerCirclePaint
 	) {
-		super(map, size, dpi, format, unit, fileName);
+		super(map, size, dpi, format, unit, fileName, 'maplibregl-marker', markerCirclePaint);
 	}
 
 	protected getRenderedMap(container: HTMLElement, style: StyleSpecification) {

--- a/sites/demo/src/routes/(demo)/mapbox/+page.svelte
+++ b/sites/demo/src/routes/(demo)/mapbox/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import mapboxgl, { Map, NavigationControl } from 'mapbox-gl';
+	import mapboxgl, { Map, Marker, NavigationControl } from 'mapbox-gl';
 	import {
 		MapboxExportControl,
 		Size,
@@ -49,13 +49,16 @@
 			container: 'map',
 			style: 'mapbox://styles/mapbox/streets-v11',
 			// style: 'https://narwassco.github.io/mapbox-stylefiles/unvt/style.json',
-			center: [35.87063, -1.08551],
-			zoom: 12,
+			center: [0, 0],
+			zoom: 1,
 			hash: true,
 			accessToken: PUBLIC_MAPBOX_ACCESSTOKEN
 		});
 
 		($mapStore as Map).addControl(new NavigationControl(), 'bottom-right');
+
+		new Marker().setLngLat([37.30467, -0.15943]).addTo($mapStore);
+		new Marker().setLngLat([30.0824, -1.9385]).addTo($mapStore);
 
 		initExportControl();
 

--- a/sites/demo/src/routes/(demo)/maplibre/+page.svelte
+++ b/sites/demo/src/routes/(demo)/maplibre/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { addProtocol, Map, NavigationControl, TerrainControl } from 'maplibre-gl';
+	import { addProtocol, Map, Marker, NavigationControl, TerrainControl } from 'maplibre-gl';
 	import {
 		MaplibreExportControl,
 		Size,
@@ -61,6 +61,9 @@
 		});
 
 		$mapStore.addControl(new NavigationControl({ visualizePitch: true }), 'bottom-right');
+
+		new Marker().setLngLat([37.30467, -0.15943]).addTo($mapStore);
+		new Marker().setLngLat([30.0824, -1.9385]).addTo($mapStore);
 
 		$mapStore.once('load', () => {
 			if ($mapStore.getSource('terrarium')) {


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

closes #16

It is difficult technically to export exactly same maker as image, but I have somehow managed to export markers as circle layer.

 `markerCirclePaint` option is added to allow changing default circle style for marker. If the option is not specified, the default marker style shall be:

```json
{
  "circle-radius": 8,
  "circle-color": "red",
  "circle-stroke-width": 1,
  "circle-stroke-color": "black"
}
```

- map with markers
![image](https://github.com/watergis/maplibre-gl-export/assets/2639701/307ffa21-67d2-41ea-88b7-8c27b300aba0)

- Exported image
![Map (6)](https://github.com/watergis/maplibre-gl-export/assets/2639701/25338e64-ccc2-42b2-b7f7-07fb4ac92d30)


## Type of Pull Request
<!-- ignore-task-list-start -->
- [x] Adding a feature
- [ ] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings
<!-- ignore-task-list-start -->
- [x] Code is up-to-date with the `main` branch
- [x] No lint errors after `pnpm lint`
- [x] Make sure all the exsiting features working well
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/watergis/maplibre-gl-export/tree/master/.github/CONTRIBUTING.md) for more details.
