### PR TITLE
fix: add other necessary files to enable Portguese language

### DIFF
--- a/.changeset/chatty-ghosts-repeat.md
+++ b/.changeset/chatty-ghosts-repeat.md
@@ -1,0 +1,6 @@
+---
+"@watergis/maplibre-gl-export": minor
+"@watergis/mapbox-gl-export": minor
+---
+
+feat: added Portuguese language which the translation was contributed by @leoneljdias via https://github.com/watergis/maplibre-gl-export/pull/133

--- a/packages/mapbox-gl-export/README.md
+++ b/packages/mapbox-gl-export/README.md
@@ -125,6 +125,7 @@ You can specify default option as follows.
   - `zhHans` Chinese Simplified
   - `zhHant` Chinese Traditional
   - `ja` Japanese
+  - `pt` Portuguese
 - AllowedSizes
   - list of allowed page sizes for export
   - available values `'LETTER'`, `'A2'`, `'A3'`, `'A4'`, `'A5'`, `'A6'`, `'B2'`, `'B3'`, `'B4'`, `'B5'`, `'B6'`

--- a/packages/maplibre-gl-export/README.md
+++ b/packages/maplibre-gl-export/README.md
@@ -96,6 +96,7 @@ You can specify default option as follows.
   - `zhHans` Chinese Simplified
   - `zhHant` Chinese Traditional
   - `ja` Japanese
+  - `pt` Portuguese
 - AllowedSizes
   - list of allowed page sizes for export
   - available values `'LETTER'`, `'A2'`, `'A3'`, `'A4'`, `'A5'`, `'A6'`, `'B2'`, `'B3'`, `'B4'`, `'B5'`, `'B6'`

--- a/packages/maplibre-gl-export/src/lib/interfaces/Language.ts
+++ b/packages/maplibre-gl-export/src/lib/interfaces/Language.ts
@@ -9,7 +9,8 @@ export const AvailableLanguages = [
 	'uk',
 	'zhHans',
 	'zhHant',
-	'ja'
+	'ja',
+	'pt'
 ] as const;
 
 export type Language = (typeof AvailableLanguages)[number];

--- a/packages/maplibre-gl-export/src/lib/local/index.ts
+++ b/packages/maplibre-gl-export/src/lib/local/index.ts
@@ -9,6 +9,7 @@ import ukranian from './uk';
 import zhHans from './zhHans';
 import zhHant from './zhHant';
 import ja from './ja';
+import pt from './pt';
 import { Language } from '../interfaces/Language';
 
 export const getTranslation = (lang: Language) => {
@@ -35,6 +36,8 @@ export const getTranslation = (lang: Language) => {
 			return zhHant;
 		case 'ja':
 			return ja;
+		case 'pt':
+			return pt;
 		default:
 			return english;
 	}


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

added other necessary files to adding Portuguese language added by https://github.com/watergis/maplibre-gl-export/pull/133

## Type of Pull Request
<!-- ignore-task-list-start -->
- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings
<!-- ignore-task-list-start -->
- [x] Code is up-to-date with the `main` branch
- [x] No lint errors after `pnpm lint`
- [x] Make sure all the exsiting features working well
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/watergis/maplibre-gl-export/tree/master/.github/CONTRIBUTING.md) for more details.
