### PR TITLE
feat: add attribution at the bottom-right of the exported image

### DIFF
--- a/.changeset/cuddly-beers-flash.md
+++ b/.changeset/cuddly-beers-flash.md
@@ -1,0 +1,6 @@
+---
+"@watergis/maplibre-gl-export": minor
+"@watergis/mapbox-gl-export": minor
+---
+
+feat: add attribution to exported image

--- a/.changeset/cuddly-beers-flash.md
+++ b/.changeset/cuddly-beers-flash.md
@@ -3,4 +3,22 @@
 "@watergis/mapbox-gl-export": minor
 ---
 
-feat: add attribution to exported image
+feat: add attribution to the bottom-right of an exported image. `attributionStyle` property is added into options. The default attribution style is 
+
+```js
+{
+  attributionStyle: {
+    textSize: 16,
+    textHaloColor: '#FFFFFF',
+    textHaloWidth: 0.8,
+    textColor: '#000000',
+    fallbackTextFont: ['Open Sans Regular']
+  }
+}
+```
+
+This plugin will try to get attribution from HTMLElement by class name of 'maplibregl-ctrl-attrib-inner' or 'mapboxgl-ctrl-attrib-inner' first. If elements are not available, it will try to make attribution text from 'attribution' property of map style source. 
+
+If `glyphs` property is not set to map style, attribution will not be added since the plugin will add attribution as a symbol layer of maplibre/mapbox. 
+
+In terms of text-font, the plugin will use the same font of the first layer which has text-font property in its layer style. If a text-font is not available from style object, fallbackTextFont will be used instead.

--- a/packages/mapbox-gl-export/README.md
+++ b/packages/mapbox-gl-export/README.md
@@ -13,23 +13,3 @@ Please consider to use [maplibre-gl-export](https://github.com/watergis/maplibre
 ## Demo & usage
 
 See [documentation](https://maplibre-gl-export.water-gis.com/).
-
-## Attribution
-
-When you use exported map, please includes attribution as follows.
-
-If you can include HTML, use this code snippet that includes links to Mapbox & OpenStreetMap:
-
-```html
-© NARWASSCO, Ltd. © <a href='https://www.mapbox.com/about/maps/'>Mapbox</a> © <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a> <strong><a href='https://www.mapbox.com/map-feedback/' target='_blank'>Improve this map</a></strong>Powered by the United Nations Vector Tile Toolkit
-```
-
-For print output or if you can’t include links, use this text-only attribution:
-
-```
-© NARWASSCO, Ltd. ©Mapbox ©OpenStreetMap contributors, Powered by the United Nations Vector Tile Toolkit
-```
-
-`© NARWASSCO, Ltd.` is default example of map data by `Narok Water and Sewerage Services Co., Ltd.`, Kenya. If you don't use current map, you don't need to use this attribution.
-
-Also, default example is using base map by United Nation Vector Tile Toolkit. That is why `Powered by the United Nations Vector Tile Toolkit` is included in above.

--- a/packages/mapbox-gl-export/src/lib/export-control.ts
+++ b/packages/mapbox-gl-export/src/lib/export-control.ts
@@ -39,6 +39,7 @@ export default class MapboxExportControl extends MaplibreExportControl implement
 			unit,
 			filename,
 			this.options.markerCirclePaint,
+			this.options.attributionStyle,
 			this.accessToken
 		);
 		mapGenerator.generate();

--- a/packages/mapbox-gl-export/src/lib/map-generator.ts
+++ b/packages/mapbox-gl-export/src/lib/map-generator.ts
@@ -1,6 +1,7 @@
 import mapboxgl, { accessToken, Map as MapboxMap } from 'mapbox-gl';
 import 'js-loading-overlay';
 import {
+	defaultAttributionStyle,
 	defaultMarkerCirclePaint,
 	DPIType,
 	Format,
@@ -32,9 +33,21 @@ export default class MapGenerator extends MapGeneratorBase {
 		unit: UnitType = Unit.mm,
 		fileName = 'map',
 		markerCirclePaint = defaultMarkerCirclePaint,
+		attributionStyle = defaultAttributionStyle,
 		accesstoken?: string
 	) {
-		super(map, size, dpi, format, unit, fileName, 'mapboxgl-marker', markerCirclePaint);
+		super(
+			map,
+			size,
+			dpi,
+			format,
+			unit,
+			fileName,
+			'mapboxgl-marker',
+			markerCirclePaint,
+			'mapboxgl-ctrl-attrib-inner',
+			attributionStyle
+		);
 		this.accesstoken = accesstoken;
 	}
 
@@ -51,7 +64,7 @@ export default class MapGenerator extends MapGeneratorBase {
 			interactive: false,
 			preserveDrawingBuffer: true,
 			fadeDuration: 0,
-			attributionControl: false,
+			// attributionControl: false,
 			// hack to read transfrom request callback function
 			// eslint-disable-next-line
 			// @ts-ignore

--- a/packages/maplibre-gl-export/README.md
+++ b/packages/maplibre-gl-export/README.md
@@ -9,21 +9,3 @@ This module is using source code of [mpetroff/print-maps](https://github.com/mpe
 ## Demo & usage
 
 See [documentation](https://maplibre-gl-export.water-gis.com/).
-
-## Attribution
-
-When you use exported map, please includes attribution as follows.
-
-If you can include HTML, use this code snippet that includes links to Mapbox & OpenStreetMap:
-```html
-© NARWASSCO, Ltd. © <a href='https://www.mapbox.com/about/maps/'>Mapbox</a> © <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a> <strong><a href='https://www.mapbox.com/map-feedback/' target='_blank'>Improve this map</a></strong>Powered by the United Nations Vector Tile Toolkit
-```
-
-For print output or if you can’t include links, use this text-only attribution:
-```
-© NARWASSCO, Ltd. ©Mapbox ©OpenStreetMap contributors, Powered by the United Nations Vector Tile Toolkit
-```
-
-`© NARWASSCO, Ltd.` is default example of map data by `Narok Water and Sewerage Services Co., Ltd.`, Kenya. If you don't use current map, you don't need to use this attribution.
-
-Also, default example is using base map by United Nation Vector Tile Toolkit. That is why `Powered by the United Nations Vector Tile Toolkit` is included in above.

--- a/packages/maplibre-gl-export/index.ts
+++ b/packages/maplibre-gl-export/index.ts
@@ -17,10 +17,12 @@ const map = new Map({
 	style: 'https://unpkg.com/@undp-data/style@latest/dist/aerialstyle.json',
 	center: [0, 0],
 	zoom: 1,
-	hash: true
+	hash: true,
+	attributionControl: false
 });
 
 map.addControl(new NavigationControl({ visualizePitch: true }), 'top-right');
+map.addControl(new maplibregl.AttributionControl({ compact: false }), 'bottom-right');
 map.addControl(
 	new MaplibreExportControl({
 		PageSize: Size.A3,

--- a/packages/maplibre-gl-export/src/lib/export-control.ts
+++ b/packages/maplibre-gl-export/src/lib/export-control.ts
@@ -18,7 +18,7 @@ import {
 	UnitType,
 	type Language
 } from './interfaces';
-import { defaultMarkerCirclePaint } from './map-generator-base';
+import { defaultAttributionStyle, defaultMarkerCirclePaint } from './map-generator-base';
 
 /**
  * Maplibre GL Export Control.
@@ -59,7 +59,8 @@ export default class MaplibreExportControl implements IControl {
 			| 'B6'
 		)[],
 		Filename: 'map',
-		markerCirclePaint: defaultMarkerCirclePaint
+		markerCirclePaint: defaultMarkerCirclePaint,
+		attributionStyle: defaultAttributionStyle
 	};
 
 	protected MAPLIB_CSS_PREFIX: string = 'maplibregl';
@@ -201,7 +202,8 @@ export default class MaplibreExportControl implements IControl {
 			format,
 			unit,
 			filename,
-			this.options.markerCirclePaint
+			this.options.markerCirclePaint,
+			this.options.attributionStyle
 		);
 		mapGenerator.generate();
 	}

--- a/packages/maplibre-gl-export/src/lib/interfaces/AttributionStyle.ts
+++ b/packages/maplibre-gl-export/src/lib/interfaces/AttributionStyle.ts
@@ -1,0 +1,7 @@
+export interface AttributionStyle {
+	textSize: number;
+	textHaloColor: string;
+	textHaloWidth: number;
+	textColor: string;
+	fallbackTextFont: string[];
+}

--- a/packages/maplibre-gl-export/src/lib/interfaces/ControlOptions.ts
+++ b/packages/maplibre-gl-export/src/lib/interfaces/ControlOptions.ts
@@ -3,6 +3,7 @@ import { FormatType } from './Format';
 import { Language } from './Language';
 import { PageOrientationType } from './PageOrientation';
 import { SizeType } from './Size';
+import { AttributionStyle } from './AttributionStyle';
 
 export interface ControlOptions {
 	PageSize?: SizeType;
@@ -15,4 +16,5 @@ export interface ControlOptions {
 	AllowedSizes?: ('LETTER' | 'A2' | 'A3' | 'A4' | 'A5' | 'A6' | 'B2' | 'B3' | 'B4' | 'B5' | 'B6')[];
 	Filename?: string;
 	markerCirclePaint?: CirclePaint;
+	attributionStyle?: AttributionStyle;
 }

--- a/packages/maplibre-gl-export/src/lib/interfaces/index.ts
+++ b/packages/maplibre-gl-export/src/lib/interfaces/index.ts
@@ -1,3 +1,4 @@
+export * from './AttributionStyle';
 export * from './ControlOptions';
 export * from './DPI';
 export * from './Format';

--- a/packages/maplibre-gl-export/src/lib/map-generator-base.ts
+++ b/packages/maplibre-gl-export/src/lib/map-generator-base.ts
@@ -299,7 +299,7 @@ export abstract class MapGeneratorBase {
 
 		if (attributions.length === 0) return false;
 
-		let attributionText = attributions.join(' | ');
+		const attributionText = attributions.join(' | ');
 
 		const attributionId = `attribution`;
 		renderMap.addSource(attributionId, {

--- a/packages/maplibre-gl-export/src/lib/map-generator.ts
+++ b/packages/maplibre-gl-export/src/lib/map-generator.ts
@@ -1,7 +1,11 @@
 import { Map as MaplibreMap, StyleSpecification } from 'maplibre-gl';
 import 'js-loading-overlay';
 import { DPIType, Format, FormatType, Size, SizeType, Unit, UnitType } from './interfaces';
-import { MapGeneratorBase, defaultMarkerCirclePaint } from './map-generator-base';
+import {
+	MapGeneratorBase,
+	defaultAttributionStyle,
+	defaultMarkerCirclePaint
+} from './map-generator-base';
 
 export default class MapGenerator extends MapGeneratorBase {
 	/**
@@ -20,9 +24,21 @@ export default class MapGenerator extends MapGeneratorBase {
 		format: FormatType = Format.PNG,
 		unit: UnitType = Unit.mm,
 		fileName = 'map',
-		markerCirclePaint = defaultMarkerCirclePaint
+		markerCirclePaint = defaultMarkerCirclePaint,
+		attributionStyle = defaultAttributionStyle
 	) {
-		super(map, size, dpi, format, unit, fileName, 'maplibregl-marker', markerCirclePaint);
+		super(
+			map,
+			size,
+			dpi,
+			format,
+			unit,
+			fileName,
+			'maplibregl-marker',
+			markerCirclePaint,
+			'maplibregl-ctrl-attrib-inner',
+			attributionStyle
+		);
 	}
 
 	protected getRenderedMap(container: HTMLElement, style: StyleSpecification) {
@@ -37,7 +53,7 @@ export default class MapGenerator extends MapGeneratorBase {
 			interactive: false,
 			preserveDrawingBuffer: true,
 			fadeDuration: 0,
-			attributionControl: false,
+			// attributionControl: false,
 			// hack to read transfrom request callback function
 			// eslint-disable-next-line
 			// @ts-ignore

--- a/sites/demo/src/routes/(doc)/+page.svelte
+++ b/sites/demo/src/routes/(doc)/+page.svelte
@@ -127,6 +127,19 @@
 				'The plugin will convert marker SVG to circle layer to be exported. Set your own circle paint property setting. As default, the following paint setting will be applied'
 		},
 		{
+			name: 'attributionStyle',
+			default: `
+{
+	textSize: 16,
+	textHaloColor: '#FFFFFF',
+	textHaloWidth: 0.8,
+	textColor: '#000000',
+	fallbackTextFont: ['Open Sans Regular']
+}`,
+			description:
+				'This plugin will try to add attribution to the bottom-right of the image as a maplibre symbol layer. The default style of attribution label can be changed per your preference. For fallbackTextFont property, it will only be used when font informaiton cannot be fetched from style object. If glyphs property is not set to your style object, attribution will not be added.'
+		},
+		{
 			name: 'accessToken',
 			default: 'mapboxgl.accessToken is used as default',
 			description: 'Mapbox access token is required'


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

It will automatically add attribution text from rendered HTML elements or attribution of style object.

It will automatically set text-max-width according to the map image width and text font size.

![Maplib](https://github.com/watergis/maplibre-gl-export/assets/2639701/6def360b-db55-48d6-9c30-1f68162c5329)
![Maplibre zoom 12](https://github.com/watergis/maplibre-gl-export/assets/2639701/4c0bbaca-8bf3-4424-9c5d-ec1f975581ea)

## Plugin

Select a plugin related to this PR.

- [x] maplibre-gl-export
- [x] mapbox-gl-export

## Type of Pull Request
<!-- ignore-task-list-start -->
- [x] Adding a feature
- [ ] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings
<!-- ignore-task-list-start -->
- [x] Code is up-to-date with the `main` branch
- [x] No lint errors after `pnpm lint`
- [x] Make sure all the exsiting features working well
- [x] Make sure a changeset file is added if your PR changes package code
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/watergis/maplibre-gl-export/tree/master/CONTRIBUTING.md) for more details.
