### PR TITLE
Update map-generator.ts to check for images data before calling addImage

### DIFF
--- a/.changeset/chilly-colts-walk.md
+++ b/.changeset/chilly-colts-walk.md
@@ -3,4 +3,4 @@
 "@watergis/mapbox-gl-export": patch
 ---
 
-Add check for actual image data before calling addImage
+fix: add check for actual image data before calling addImage by @jmbarbier

--- a/.changeset/chilly-colts-walk.md
+++ b/.changeset/chilly-colts-walk.md
@@ -1,0 +1,6 @@
+---
+"@watergis/maplibre-gl-export": patch
+"@watergis/mapbox-gl-export": patch
+---
+
+Add check for actual image data before calling addImage

--- a/packages/mapbox-gl-export/src/lib/map-generator.ts
+++ b/packages/mapbox-gl-export/src/lib/map-generator.ts
@@ -77,6 +77,7 @@ export default class MapGenerator extends MapGeneratorBase {
 		if (images && Object.keys(images)?.length > 0) {
 			Object.keys(images).forEach((key) => {
 				if (!key) return;
+				if (!images[key].data) return;
 				renderMap.addImage(key, images[key].data);
 			});
 		}

--- a/packages/maplibre-gl-export/src/lib/map-generator.ts
+++ b/packages/maplibre-gl-export/src/lib/map-generator.ts
@@ -70,6 +70,7 @@ export default class MapGenerator extends MapGeneratorBase {
 		// the below code was added by https://github.com/watergis/maplibre-gl-export/pull/18.
 		const images = ((this.map as MaplibreMap).style.imageManager || {}).images || [];
 		Object.keys(images).forEach((key) => {
+			if (!images[key].data) return;
 			renderMap.addImage(key, images[key].data);
 		});
 


### PR DESCRIPTION
This is a fix for https://github.com/watergis/maplibre-gl-export/issues/156

Thank you for submitting a pull request!

## Description

Added a check for existing image data before calling addImage.

## Plugin

Select a plugin related to this PR.

- [x] maplibre-gl-export
- [ ] mapbox-gl-export

## Type of Pull Request
<!-- ignore-task-list-start -->
- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings
<!-- ignore-task-list-start -->
- [x] Code is up-to-date with the `main` branch
- [x] No lint errors after `pnpm lint`
- [x] Make sure all the exsiting features working well
- [x] Make sure a changeset file is added if your PR changes package code
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/watergis/maplibre-gl-export/tree/master/CONTRIBUTING.md) for more details.
