### PR TITLE
Fix broken build badge & link to build page in GitHub Actions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # maplibre-gl-export
 
 ![License](https://img.shields.io/github/license/watergis/maplibre-gl-export)
-![build](https://github.com/watergis/maplibre-gl-export/workflows/build/badge.svg)
+[![build](https://img.shields.io/github/actions/workflow/status/watergis/maplibre-gl-export/build.yml)](https://github.com/watergis/maplibre-gl-export/actions/workflows/build.yml)
 [![Netlify Status](https://api.netlify.com/api/v1/badges/2ca781c3-2680-4c17-9219-4992c1f2a44e/deploy-status)](https://app.netlify.com/sites/maplibre-gl-export/deploys)
 ![GitHub repo size](https://img.shields.io/github/repo-size/watergis/maplibre-gl-export)
 


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

Fixed the broken build badge, made the image link to the `watergis/maplibre-gl-export` build action page.

![image](https://github.com/user-attachments/assets/267a4478-a830-41b7-9ce8-2248dbb913f9)

## Plugin

Select a plugin related to this PR.

- [x] maplibre-gl-export
- [x] mapbox-gl-export

## Type of Pull Request
<!-- ignore-task-list-start -->
- [ ] Adding a feature
- [x] Fixing a bug
- [x] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings
<!-- ignore-task-list-start -->
- [x] Code is up-to-date with the `main` branch
- [x] No lint errors after `pnpm lint`
- [x] Make sure all the existing features working well
- [ ] Make sure a changeset file is added if your PR changes package code
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/watergis/maplibre-gl-export/tree/master/CONTRIBUTING.md) for more details.
