### PR TITLE
feat: generate proper scalebar control and north icon and attribution on canvas

### DIFF
--- a/.changeset/olive-moons-attack-mapbox.md
+++ b/.changeset/olive-moons-attack-mapbox.md
@@ -1,0 +1,56 @@
+---
+'@watergis/mapbox-gl-export': major
+---
+
+feat: draw the attribution, north icon and a new scale bar onto the exported image with a composed 2D canvas instead of adding them as symbol layers.
+
+The exported map canvas is now composed onto a 2D canvas before being saved, and the overlays are drawn on top of it. A `ScaleControl` and an `AttributionControl` are added to the hidden map used for rendering, and their elements are rasterized and drawn onto the exported image, keeping mapbox's native styling. This removes the limitations of the previous symbol layer approach:
+
+- the attribution no longer requires the `glyphs` property in the style
+- the attribution and the north icon are no longer hidden at zoom levels below 2
+- the attribution can now be placed in any of the four corners
+- a scale bar is exported for the first time, and can be toggled from the export panel together with the north icon
+
+### Usage
+
+The scale bar and north icon can be toggled from the export panel, and both overlays can be configured through `MapboxExportControl`:
+
+```ts
+import { MapboxExportControl } from '@watergis/mapbox-gl-export';
+import { Size, PageOrientation, Format, DPI } from '@watergis/maplibre-gl-export';
+
+const exportControl = new MapboxExportControl({
+  PageSize: Size.A3,
+  PageOrientation: PageOrientation.Landscape,
+  Format: Format.PNG,
+  DPI: DPI[300],
+  // attribution: rasterized from mapbox's own AttributionControl (keeps native styling)
+  attributionOptions: {
+    visibility: 'visible',
+    position: 'bottom-right', // any of the four corners
+    margin: 10, // distance from the map edge at 96 DPI
+    compact: false,
+    customAttribution: '© My Company'
+  },
+  // scale bar: exported for the first time
+  scalebarOptions: {
+    visibility: 'visible',
+    position: 'bottom-left',
+    margin: 10,
+    maxWidth: 100,
+    unit: 'metric' // 'metric' | 'imperial' | 'nautical'
+  },
+  // north icon
+  northIconOptions: {
+    visibility: 'visible',
+    position: 'top-right',
+    margin: 10
+  }
+});
+
+map.addControl(exportControl, 'top-right');
+```
+
+### Breaking changes
+
+`attributionOptions.style` (`textSize`, `textColor`, `textHaloColor`, `textHaloWidth`, `fallbackTextFont`) has been removed. The attribution is now rasterized from mapbox's own `AttributionControl` element, so it keeps the library's native styling and there is nothing to configure. `attributionOptions` now accepts `compact` and `customAttribution` of mapbox's `AttributionControlOptions`, plus `visibility`, `position` (any of the four corners) and `margin`.

--- a/.changeset/olive-moons-attack.md
+++ b/.changeset/olive-moons-attack.md
@@ -1,0 +1,55 @@
+---
+'@watergis/maplibre-gl-export': major
+---
+
+feat: draw the attribution, north icon and a new scale bar onto the exported image with a composed 2D canvas instead of adding them as symbol layers.
+
+The exported map canvas is now composed onto a 2D canvas before being saved, and the overlays are drawn on top of it. A `ScaleControl` and an `AttributionControl` are added to the hidden map used for rendering, and their elements are rasterized and drawn onto the exported image, keeping maplibre's native styling. This removes the limitations of the previous symbol layer approach:
+
+- the attribution no longer requires the `glyphs` property in the style
+- the attribution and the north icon are no longer hidden at zoom levels below 2
+- the attribution can now be placed in any of the four corners
+- a scale bar is exported for the first time, and can be toggled from the export panel together with the north icon
+
+### Usage
+
+The scale bar and north icon can be toggled from the export panel, and both overlays can be configured through `MaplibreExportControl`:
+
+```ts
+import { MaplibreExportControl, Size, PageOrientation, Format, DPI } from '@watergis/maplibre-gl-export';
+
+const exportControl = new MaplibreExportControl({
+  PageSize: Size.A3,
+  PageOrientation: PageOrientation.Landscape,
+  Format: Format.PNG,
+  DPI: DPI[300],
+  // attribution: rasterized from maplibre's own AttributionControl (keeps native styling)
+  attributionOptions: {
+    visibility: 'visible',
+    position: 'bottom-right', // any of the four corners
+    margin: 10, // distance from the map edge at 96 DPI
+    compact: false,
+    customAttribution: '© My Company'
+  },
+  // scale bar: exported for the first time
+  scalebarOptions: {
+    visibility: 'visible',
+    position: 'bottom-left',
+    margin: 10,
+    maxWidth: 100,
+    unit: 'metric' // 'metric' | 'imperial' | 'nautical'
+  },
+  // north icon
+  northIconOptions: {
+    visibility: 'visible',
+    position: 'top-right',
+    margin: 10
+  }
+});
+
+map.addControl(exportControl, 'top-right');
+```
+
+### Breaking changes
+
+`attributionOptions.style` (`textSize`, `textColor`, `textHaloColor`, `textHaloWidth`, `fallbackTextFont`) has been removed. The attribution is now rasterized from maplibre's own `AttributionControl` element, so it keeps the library's native styling and there is nothing to configure. `attributionOptions` now accepts `compact` and `customAttribution` of maplibre's `AttributionControlOptions`, plus `visibility`, `position` (any of the four corners) and `margin`.

--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
   "engines": {
     "pnpm": "^11.0.0"
   },
-  "type": "module"
+  "type": "module",
+  "dependencies": {
+    "html-to-image": "^1.11.13"
+  }
 }

--- a/packages/mapbox-gl-export/src/lib/export-control.ts
+++ b/packages/mapbox-gl-export/src/lib/export-control.ts
@@ -35,18 +35,18 @@ export default class MapboxExportControl extends MaplibreExportControl implement
 		unit: UnitType,
 		filename?: string
 	) {
-		const mapGenerator = new MapGenerator(
-			map as MapboxMap,
+		const mapGenerator = new MapGenerator(map as MapboxMap, {
 			size,
 			dpi,
 			format,
 			unit,
-			filename,
-			this.options.markerCirclePaint,
-			this.options.attributionOptions,
-			this.options.northIconOptions,
-			this.accessToken
-		);
+			fileName: filename,
+			markerCirclePaint: this.options.markerCirclePaint,
+			attributionOptions: this.options.attributionOptions,
+			scalebarOptions: this.options.scalebarOptions,
+			northIconOptions: this.options.northIconOptions,
+			accessToken: this.accessToken
+		});
 		mapGenerator.generate();
 	}
 }

--- a/packages/mapbox-gl-export/src/lib/map-generator.ts
+++ b/packages/mapbox-gl-export/src/lib/map-generator.ts
@@ -1,17 +1,20 @@
-import mapboxgl, { Map as MapboxMap } from 'mapbox-gl';
+import mapboxgl, {
+	AttributionControl,
+	ControlPosition,
+	Map as MapboxMap,
+	ScaleControl
+} from 'mapbox-gl';
 import {
-	defaultAttributionOptions,
-	defaultMarkerCirclePaint,
-	defaultNorthIconOptions,
-	DPIType,
-	Format,
-	FormatType,
+	AttributionOptions,
 	MapGeneratorBase,
-	Size,
-	SizeType,
-	Unit,
-	UnitType
+	MapGeneratorConfig,
+	ScalebarOptions
 } from '@watergis/maplibre-gl-export';
+
+export interface MapboxMapGeneratorConfig extends MapGeneratorConfig {
+	/** Mapbox access token. `mapboxgl.accessToken` is used when it is not set */
+	accessToken?: string;
+}
 
 export default class MapGenerator extends MapGeneratorBase {
 	private accesstoken: string | undefined;
@@ -19,40 +22,16 @@ export default class MapGenerator extends MapGeneratorBase {
 	/**
 	 * Constructor
 	 * @param map MapboxMap object
-	 * @param size layout size. default is A4
-	 * @param dpi dpi value. default is 300
-	 * @param format image format. default is PNG
-	 * @param unit length unit. default is mm
-	 * @param fileName file name. default is 'map'
+	 * @param config generator settings. See {@link MapboxMapGeneratorConfig}
 	 */
-	constructor(
-		map: MapboxMap,
-		size: SizeType = Size.A4,
-		dpi: DPIType = 300,
-		format: FormatType = Format.PNG,
-		unit: UnitType = Unit.mm,
-		fileName = 'map',
-		markerCirclePaint = defaultMarkerCirclePaint,
-		attributionOptions = defaultAttributionOptions,
-		northIconOptions = defaultNorthIconOptions,
-		accesstoken?: string
-	) {
+	constructor(map: MapboxMap, config: MapboxMapGeneratorConfig = {}) {
 		super(
 			// eslint-disable-next-line
 			// @ts-ignore
 			map,
-			size,
-			dpi,
-			format,
-			unit,
-			fileName,
-			'mapboxgl-marker',
-			markerCirclePaint,
-			'mapboxgl-ctrl-attrib-inner',
-			attributionOptions,
-			northIconOptions
+			{ ...config, cssPrefix: 'mapboxgl' }
 		);
-		this.accesstoken = accesstoken;
+		this.accesstoken = config.accessToken;
 	}
 
 	/**
@@ -91,7 +70,8 @@ export default class MapGenerator extends MapGeneratorBase {
 			interactive: false,
 			preserveDrawingBuffer: true,
 			fadeDuration: 0,
-			// attributionControl: false,
+			// the attribution control is added explicitly below so that its options can be controlled
+			attributionControl: false,
 			// hack to read transform request callback function
 			// eslint-disable-next-line
 			// @ts-ignore
@@ -114,6 +94,29 @@ export default class MapGenerator extends MapGeneratorBase {
 			});
 		}
 
+		this.addScaleControl(renderMap, this.scalebarOptions);
+		this.addAttributionControl(renderMap, this.attributionOptions);
+
 		return renderMap;
+	}
+
+	protected addScaleControl(renderMap: MapboxMap, options: ScalebarOptions) {
+		if (options.visibility === 'none') return;
+		const control = new ScaleControl({
+			maxWidth: options.maxWidth,
+			unit: options.unit
+		});
+		renderMap.addControl(control, (options.position ?? 'bottom-left') as ControlPosition);
+	}
+
+	protected addAttributionControl(renderMap: MapboxMap, options: AttributionOptions) {
+		if (options.visibility === 'none') return;
+		const control = new AttributionControl({
+			customAttribution: options.customAttribution,
+			// never collapse. the responsive default hides the text on maps narrower than 640px,
+			// which happens for smaller page sizes.
+			compact: false
+		});
+		renderMap.addControl(control, (options.position ?? 'bottom-right') as ControlPosition);
 	}
 }

--- a/packages/maplibre-gl-export/index.ts
+++ b/packages/maplibre-gl-export/index.ts
@@ -47,6 +47,11 @@ map.addControl(
 			position: 'bottom-right',
 			visibility: 'visible'
 		},
+		scalebarOptions: {
+			position: 'bottom-left',
+			unit: 'metric',
+			visibility: 'visible'
+		},
 		northIconOptions: {
 			position: 'top-right',
 			visibility: 'visible'

--- a/packages/maplibre-gl-export/package.json
+++ b/packages/maplibre-gl-export/package.json
@@ -75,6 +75,7 @@
 		"vite": "^8.1.5"
 	},
 	"dependencies": {
+		"html-to-image": "^1.11.13",
 		"jspdf": "^4.2.1"
 	},
 	"peerDependencies": {

--- a/packages/maplibre-gl-export/src/lib/export-control.ts
+++ b/packages/maplibre-gl-export/src/lib/export-control.ts
@@ -21,7 +21,8 @@ import {
 import {
 	defaultAttributionOptions,
 	defaultMarkerCirclePaint,
-	defaultNorthIconOptions
+	defaultNorthIconOptions,
+	defaultScalebarOptions
 } from './map-generator-base';
 
 /**
@@ -55,6 +56,7 @@ export default class MaplibreExportControl implements IControl {
 		Filename: 'map',
 		markerCirclePaint: defaultMarkerCirclePaint,
 		attributionOptions: defaultAttributionOptions,
+		scalebarOptions: defaultScalebarOptions,
 		northIconOptions: defaultNorthIconOptions
 	};
 
@@ -63,10 +65,16 @@ export default class MaplibreExportControl implements IControl {
 	constructor(options: ControlOptions) {
 		if (options) {
 			options.attributionOptions = Object.assign(
+				{},
 				defaultAttributionOptions,
 				options.attributionOptions
 			);
-			options.northIconOptions = Object.assign(defaultNorthIconOptions, options.northIconOptions);
+			options.scalebarOptions = Object.assign({}, defaultScalebarOptions, options.scalebarOptions);
+			options.northIconOptions = Object.assign(
+				{},
+				defaultNorthIconOptions,
+				options.northIconOptions
+			);
 			this.options = Object.assign(this.options, options);
 		}
 		this.onDocumentClick = this.onDocumentClick.bind(this);
@@ -149,6 +157,20 @@ export default class MaplibreExportControl implements IControl {
 		);
 		table.appendChild(tr4);
 
+		const tr5 = this.createCheckbox(
+			this.getTranslation().Scalebar,
+			'scalebar',
+			this.options.scalebarOptions?.visibility !== 'none'
+		);
+		table.appendChild(tr5);
+
+		const tr6 = this.createCheckbox(
+			this.getTranslation().NorthIcon,
+			'north-icon',
+			this.options.northIconOptions?.visibility !== 'none'
+		);
+		table.appendChild(tr6);
+
 		this.exportContainer.appendChild(table);
 
 		const generateButton = document.createElement('button');
@@ -168,11 +190,27 @@ export default class MaplibreExportControl implements IControl {
 			const dpiType: HTMLSelectElement = <HTMLSelectElement>(
 				document.getElementById('mapbox-gl-export-dpi-type')
 			);
+			const scalebar: HTMLInputElement = <HTMLInputElement>(
+				document.getElementById('mapbox-gl-export-scalebar')
+			);
+			const northIcon: HTMLInputElement = <HTMLInputElement>(
+				document.getElementById('mapbox-gl-export-north-icon')
+			);
 			const orientValue = pageOrientation.value;
 			let pageSizeValue = JSON.parse(pageSize.value);
 			if (orientValue === PageOrientation.Portrait) {
 				pageSizeValue = pageSizeValue.reverse();
 			}
+
+			// reflect the panel toggles before generating so that `generateMap` (which is also
+			// overridden by MapboxExportControl) can simply read them from `this.options`.
+			if (this.options.scalebarOptions) {
+				this.options.scalebarOptions.visibility = scalebar?.checked ? 'visible' : 'none';
+			}
+			if (this.options.northIconOptions) {
+				this.options.northIconOptions.visibility = northIcon?.checked ? 'visible' : 'none';
+			}
+
 			this.generateMap(
 				map,
 				pageSizeValue,
@@ -195,17 +233,17 @@ export default class MaplibreExportControl implements IControl {
 		unit: UnitType,
 		filename?: string
 	) {
-		const mapGenerator = new MapGenerator(
-			map as MaplibreMap,
+		const mapGenerator = new MapGenerator(map as MaplibreMap, {
 			size,
 			dpi,
 			format,
 			unit,
-			filename,
-			this.options.markerCirclePaint,
-			this.options.attributionOptions,
-			this.options.northIconOptions
-		);
+			fileName: filename,
+			markerCirclePaint: this.options.markerCirclePaint,
+			attributionOptions: this.options.attributionOptions,
+			scalebarOptions: this.options.scalebarOptions,
+			northIconOptions: this.options.northIconOptions
+		});
 		mapGenerator.generate();
 	}
 
@@ -244,6 +282,33 @@ export default class MaplibreExportControl implements IControl {
 		tr1.appendChild(tdLabel);
 		tr1.appendChild(tdContent);
 		return tr1;
+	}
+
+	/**
+	 * Create a table row with a checkbox. It shares the layout of {@link createSelection}.
+	 * @param title label of the checkbox
+	 * @param type suffix of the element id (`mapbox-gl-export-${type}`)
+	 * @param checked initial state
+	 */
+	private createCheckbox(title: string, type: string, checked: boolean): HTMLElement {
+		const label = document.createElement('label');
+		label.textContent = title;
+		label.setAttribute('for', `mapbox-gl-export-${type}`);
+
+		const content = document.createElement('input');
+		content.type = 'checkbox';
+		content.setAttribute('id', `mapbox-gl-export-${type}`);
+		content.setAttribute('name', type);
+		content.checked = checked;
+
+		const tr = document.createElement('TR');
+		const tdLabel = document.createElement('TD');
+		const tdContent = document.createElement('TD');
+		tdLabel.appendChild(label);
+		tdContent.appendChild(content);
+		tr.appendChild(tdLabel);
+		tr.appendChild(tdContent);
+		return tr;
 	}
 
 	public onRemove(): void {

--- a/packages/maplibre-gl-export/src/lib/interfaces/AttributionStyle.ts
+++ b/packages/maplibre-gl-export/src/lib/interfaces/AttributionStyle.ts
@@ -1,14 +1,14 @@
-export interface AttributionStyle {
-	textSize: number;
-	textHaloColor: string;
-	textHaloWidth: number;
-	textColor: string;
-	fallbackTextFont: string[];
-}
+import type { AttributionControlOptions, ControlPosition } from 'maplibre-gl';
 
-export interface AttributionOptions {
-	style?: AttributionStyle;
+/**
+ * Attribution options. It extends maplibre's `AttributionControlOptions`
+ * (`compact` and `customAttribution`) which are passed to the AttributionControl
+ * added to the hidden map. The control element is then rasterized and drawn on the
+ * exported canvas, so the attribution keeps maplibre's native styling.
+ */
+export interface AttributionOptions extends AttributionControlOptions {
 	visibility?: 'visible' | 'none';
-	// TODO: top-left and bottom-left have issues of text-max-width setting
-	position?: 'top-right' | 'bottom-right';
+	position?: ControlPosition;
+	/** Distance between the attribution and the edge of the map area at 96 DPI */
+	margin?: number;
 }

--- a/packages/maplibre-gl-export/src/lib/interfaces/ControlOptions.ts
+++ b/packages/maplibre-gl-export/src/lib/interfaces/ControlOptions.ts
@@ -1,16 +1,20 @@
+import type { ControlPosition } from 'maplibre-gl';
 import { CirclePaint } from 'mapbox-gl';
 import { FormatType } from './Format';
 import { Language } from './Language';
 import { PageOrientationType } from './PageOrientation';
 import { SizeType } from './Size';
 import { AttributionOptions } from './AttributionStyle';
+import { ScalebarOptions } from './ScalebarOptions';
 
 export interface NorthIconOptions {
 	image?: string;
 	imageName?: string;
 	imageSizeFraction?: number;
 	visibility?: 'visible' | 'none';
-	position?: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+	position?: ControlPosition;
+	/** Distance between the north icon and the edge of the map area at 96 DPI */
+	margin?: number;
 }
 
 export interface ControlOptions {
@@ -25,5 +29,6 @@ export interface ControlOptions {
 	Filename?: string;
 	markerCirclePaint?: CirclePaint;
 	attributionOptions?: AttributionOptions;
+	scalebarOptions?: ScalebarOptions;
 	northIconOptions?: NorthIconOptions;
 }

--- a/packages/maplibre-gl-export/src/lib/interfaces/ScalebarOptions.ts
+++ b/packages/maplibre-gl-export/src/lib/interfaces/ScalebarOptions.ts
@@ -1,0 +1,17 @@
+import type { ControlPosition, ScaleControlOptions } from 'maplibre-gl';
+
+/**
+ * Scale bar options. It extends maplibre's `ScaleControlOptions` (`maxWidth` and `unit`)
+ * which are passed to the ScaleControl added to the hidden map. The rendered control
+ * element is then rasterized and drawn on the exported canvas.
+ *
+ * Note: `unit` here is the distance unit of the scale bar
+ * (`'metric'` / `'imperial'` / `'nautical'`), which is unrelated to the
+ * page length unit {@link Unit} (`mm` / `in`) used for the export layout.
+ */
+export interface ScalebarOptions extends ScaleControlOptions {
+	visibility?: 'visible' | 'none';
+	position?: ControlPosition;
+	/** Distance between the scale bar and the edge of the map area at 96 DPI */
+	margin?: number;
+}

--- a/packages/maplibre-gl-export/src/lib/interfaces/Translation.ts
+++ b/packages/maplibre-gl-export/src/lib/interfaces/Translation.ts
@@ -4,6 +4,8 @@ export type Translation = {
 	Format: string;
 	DPI: string;
 	Generate: string;
+	Scalebar: string;
+	NorthIcon: string;
 	LanguageName: string;
 	LanguageCode: string;
 };

--- a/packages/maplibre-gl-export/src/lib/interfaces/index.ts
+++ b/packages/maplibre-gl-export/src/lib/interfaces/index.ts
@@ -4,6 +4,7 @@ export * from './DPI';
 export * from './Format';
 export * from './Language';
 export * from './PageOrientation';
+export * from './ScalebarOptions';
 export * from './Size';
 export * from './Translation';
 export * from './Unit';

--- a/packages/maplibre-gl-export/src/lib/local/ca.ts
+++ b/packages/maplibre-gl-export/src/lib/local/ca.ts
@@ -6,6 +6,8 @@ const translation: Translation = {
 	Format: 'Format',
 	DPI: 'DPI',
 	Generate: 'Genera',
+	Scalebar: "Barra d'escala",
+	NorthIcon: 'Icona del nord',
 	LanguageName: 'Catalan',
 	LanguageCode: 'ca'
 };

--- a/packages/maplibre-gl-export/src/lib/local/de.ts
+++ b/packages/maplibre-gl-export/src/lib/local/de.ts
@@ -6,6 +6,8 @@ const translation: Translation = {
 	Format: 'Dateiformat',
 	DPI: 'Druckauflösung',
 	Generate: 'Erstellen',
+	Scalebar: 'Maßstabsleiste',
+	NorthIcon: 'Nordpfeil',
 	LanguageName: 'Deutsch',
 	LanguageCode: 'de'
 };

--- a/packages/maplibre-gl-export/src/lib/local/en.ts
+++ b/packages/maplibre-gl-export/src/lib/local/en.ts
@@ -6,6 +6,8 @@ const translation: Translation = {
 	Format: 'Format',
 	DPI: 'DPI',
 	Generate: 'Generate',
+	Scalebar: 'Scale bar',
+	NorthIcon: 'North icon',
 	LanguageName: 'English',
 	LanguageCode: 'en'
 };

--- a/packages/maplibre-gl-export/src/lib/local/es.ts
+++ b/packages/maplibre-gl-export/src/lib/local/es.ts
@@ -6,6 +6,8 @@ const translation: Translation = {
 	Format: 'Formato',
 	DPI: 'DPI',
 	Generate: 'Generar',
+	Scalebar: 'Barra de escala',
+	NorthIcon: 'Icono del norte',
 	LanguageName: 'Española',
 	LanguageCode: 'es'
 };

--- a/packages/maplibre-gl-export/src/lib/local/fi.ts
+++ b/packages/maplibre-gl-export/src/lib/local/fi.ts
@@ -6,6 +6,8 @@ const translation: Translation = {
 	Format: 'Muoto',
 	DPI: 'DPI',
 	Generate: 'Generoi',
+	Scalebar: 'Mittakaava',
+	NorthIcon: 'Pohjoisnuoli',
 	LanguageName: 'Suomalainen',
 	LanguageCode: 'fi'
 };

--- a/packages/maplibre-gl-export/src/lib/local/fr.ts
+++ b/packages/maplibre-gl-export/src/lib/local/fr.ts
@@ -6,6 +6,8 @@ const translation: Translation = {
 	Format: 'Format',
 	DPI: 'DPI',
 	Generate: 'Générer',
+	Scalebar: "Barre d'échelle",
+	NorthIcon: 'Flèche du nord',
 	LanguageName: 'Français',
 	LanguageCode: 'fr'
 };

--- a/packages/maplibre-gl-export/src/lib/local/ja.ts
+++ b/packages/maplibre-gl-export/src/lib/local/ja.ts
@@ -6,6 +6,8 @@ const translation: Translation = {
 	Format: 'フォーマット',
 	DPI: 'DPI（解像度）',
 	Generate: '出力',
+	Scalebar: 'スケールバー',
+	NorthIcon: '方位記号',
 	LanguageName: '日本語',
 	LanguageCode: 'ja'
 };

--- a/packages/maplibre-gl-export/src/lib/local/pt.ts
+++ b/packages/maplibre-gl-export/src/lib/local/pt.ts
@@ -6,6 +6,8 @@ const translation: Translation = {
 	Format: 'Formato',
 	DPI: 'DPI',
 	Generate: 'Gerar',
+	Scalebar: 'Barra de escala',
+	NorthIcon: 'Ícone do norte',
 	LanguageName: 'Português',
 	LanguageCode: 'pt'
 };

--- a/packages/maplibre-gl-export/src/lib/local/ru.ts
+++ b/packages/maplibre-gl-export/src/lib/local/ru.ts
@@ -6,6 +6,8 @@ const translation: Translation = {
 	Format: 'Формат',
 	DPI: 'Разрешение (DPI)',
 	Generate: 'Сгенерировать',
+	Scalebar: 'Масштабная линейка',
+	NorthIcon: 'Указатель севера',
 	LanguageName: 'русский',
 	LanguageCode: 'ru'
 };

--- a/packages/maplibre-gl-export/src/lib/local/sv.ts
+++ b/packages/maplibre-gl-export/src/lib/local/sv.ts
@@ -6,6 +6,8 @@ const translation: Translation = {
 	Format: 'Format',
 	DPI: 'DPI',
 	Generate: 'Generera',
+	Scalebar: 'Skalstock',
+	NorthIcon: 'Norrpil',
 	LanguageName: 'Svenska',
 	LanguageCode: 'sv'
 };

--- a/packages/maplibre-gl-export/src/lib/local/uk.ts
+++ b/packages/maplibre-gl-export/src/lib/local/uk.ts
@@ -6,6 +6,8 @@ const translation: Translation = {
 	Format: 'Формат',
 	DPI: 'DPI',
 	Generate: 'Згенерувати',
+	Scalebar: 'Масштабна лінійка',
+	NorthIcon: 'Покажчик півночі',
 	LanguageName: 'українська',
 	LanguageCode: 'uk'
 };

--- a/packages/maplibre-gl-export/src/lib/local/vi.ts
+++ b/packages/maplibre-gl-export/src/lib/local/vi.ts
@@ -6,6 +6,8 @@ const translation: Translation = {
 	Format: 'Định dạng',
 	DPI: 'Mật độ điểm ảnh (DPI)',
 	Generate: 'Tạo',
+	Scalebar: 'Thanh tỷ lệ',
+	NorthIcon: 'Biểu tượng hướng bắc',
 	LanguageName: 'Tiếng Việt',
 	LanguageCode: 'vi'
 };

--- a/packages/maplibre-gl-export/src/lib/local/zhHans.ts
+++ b/packages/maplibre-gl-export/src/lib/local/zhHans.ts
@@ -6,6 +6,8 @@ const translation: Translation = {
 	Format: '格式',
 	DPI: '像素',
 	Generate: '导出',
+	Scalebar: '比例尺',
+	NorthIcon: '指北针',
 	LanguageName: '简体字',
 	LanguageCode: 'zhHans'
 };

--- a/packages/maplibre-gl-export/src/lib/local/zhHant.ts
+++ b/packages/maplibre-gl-export/src/lib/local/zhHant.ts
@@ -6,6 +6,8 @@ const translation: Translation = {
 	Format: '格式',
 	DPI: '像素',
 	Generate: '導出',
+	Scalebar: '比例尺',
+	NorthIcon: '指北針',
 	LanguageName: '繁体字',
 	LanguageCode: 'zhHant'
 };

--- a/packages/maplibre-gl-export/src/lib/map-generator-base.ts
+++ b/packages/maplibre-gl-export/src/lib/map-generator-base.ts
@@ -27,21 +27,18 @@
  * THE SOFTWARE.
  */
 
+import { toCanvas } from 'html-to-image';
 import { jsPDF } from 'jspdf';
-import {
-	Map as MaplibreMap,
-	SourceSpecification,
-	StyleSpecification,
-	SymbolLayerSpecification
-} from 'maplibre-gl';
+import type { ControlPosition } from 'maplibre-gl';
+import { Map as MaplibreMap, StyleSpecification } from 'maplibre-gl';
 import { CirclePaint, Map as MapboxMap } from 'mapbox-gl';
 import {
 	AttributionOptions,
-	AttributionStyle,
 	DPIType,
 	Format,
 	FormatType,
 	NorthIconOptions,
+	ScalebarOptions,
 	Size,
 	SizeType,
 	Unit,
@@ -56,15 +53,17 @@ export const defaultMarkerCirclePaint: CirclePaint = {
 };
 
 export const defaultAttributionOptions: AttributionOptions = {
-	style: {
-		textSize: 16,
-		textHaloColor: '#FFFFFF',
-		textHaloWidth: 0.8,
-		textColor: '#000000',
-		fallbackTextFont: ['Open Sans Regular']
-	},
 	visibility: 'visible',
-	position: 'bottom-right'
+	position: 'bottom-right',
+	margin: 10
+};
+
+export const defaultScalebarOptions: ScalebarOptions = {
+	maxWidth: 100,
+	unit: 'metric',
+	visibility: 'visible',
+	position: 'bottom-left',
+	margin: 10
 };
 
 export const defaultNorthIconOptions: NorthIconOptions = {
@@ -72,8 +71,40 @@ export const defaultNorthIconOptions: NorthIconOptions = {
 	imageName: 'gl-export-north-icon',
 	imageSizeFraction: 0.05,
 	visibility: 'visible',
-	position: 'top-right'
+	position: 'top-right',
+	margin: 10
 };
+
+/**
+ * CSS class prefix of the underlying library. It is used to look up markers and
+ * the DOM elements of the scale / attribution controls on the hidden map.
+ */
+export type CssPrefix = 'maplibregl' | 'mapboxgl';
+
+export interface MapGeneratorConfig {
+	/** layout size. default is A4 */
+	size?: SizeType;
+	/** dpi value. default is 300 */
+	dpi?: DPIType;
+	/** image format. default is PNG */
+	format?: FormatType;
+	/** length unit of the page layout. default is mm */
+	unit?: UnitType;
+	/** file name. default is 'map' */
+	fileName?: string;
+	/** CSS class prefix of the underlying library. default is 'maplibregl' */
+	cssPrefix?: CssPrefix;
+	markerCirclePaint?: CirclePaint;
+	attributionOptions?: AttributionOptions;
+	scalebarOptions?: ScalebarOptions;
+	northIconOptions?: NorthIconOptions;
+}
+
+/** Timeout for waiting the `load` event of the hidden map */
+const LOAD_TIMEOUT_MS = 30000;
+
+/** Timeout for waiting the `idle` event of the hidden map */
+const IDLE_TIMEOUT_MS = 5000;
 
 export abstract class MapGeneratorBase {
 	protected map: MaplibreMap | MapboxMap;
@@ -90,56 +121,82 @@ export abstract class MapGeneratorBase {
 
 	protected fileName: string;
 
-	protected markerClassName: string;
+	protected cssPrefix: CssPrefix;
 
 	protected markerCirclePaint: CirclePaint;
 
-	protected attributionClassName: string;
-
 	protected attributionOptions: AttributionOptions;
+
+	protected scalebarOptions: ScalebarOptions;
 
 	protected northIconOptions: NorthIconOptions;
 
+	/** Hidden container holding the map used for rendering. Available while generating. */
+	protected hiddenContainer: HTMLElement | undefined;
+
 	/**
 	 * Constructor
-	 * @param map MaplibreMap object
-	 * @param size layout size. default is A4
-	 * @param dpi dpi value. default is 300
-	 * @param format image format. default is PNG
-	 * @param unit length unit. default is mm
-	 * @param fileName file name. default is 'map'
+	 * @param map MaplibreMap or MapboxMap object
+	 * @param config generator settings. See {@link MapGeneratorConfig}
 	 */
-	constructor(
-		map: MaplibreMap | MapboxMap,
-		size: SizeType = Size.A4,
-		dpi: DPIType = 300,
-		format: FormatType = Format.PNG,
-		unit: UnitType = Unit.mm,
-		fileName = 'map',
-		markerClassName = 'maplibregl-marker',
-		markerCirclePaint = defaultMarkerCirclePaint,
-		attributionClassName = 'maplibregl-ctrl-attrib-inner',
-		attributionOptions = defaultAttributionOptions,
-		northIconOptions = defaultNorthIconOptions
-	) {
+	constructor(map: MaplibreMap | MapboxMap, config: MapGeneratorConfig = {}) {
+		const size = config.size ?? Size.A4;
 		this.map = map;
 		this.width = size[0];
 		this.height = size[1];
-		this.dpi = dpi;
-		this.format = format;
-		this.unit = unit;
-		this.fileName = fileName;
-		this.markerClassName = markerClassName;
-		this.markerCirclePaint = markerCirclePaint;
-		this.attributionClassName = attributionClassName;
-		this.attributionOptions = attributionOptions;
-		this.northIconOptions = northIconOptions;
+		this.dpi = config.dpi ?? 300;
+		this.format = config.format ?? Format.PNG;
+		this.unit = config.unit ?? Unit.mm;
+		this.fileName = config.fileName ?? 'map';
+		this.cssPrefix = config.cssPrefix ?? 'maplibregl';
+		this.markerCirclePaint = config.markerCirclePaint ?? defaultMarkerCirclePaint;
+		this.attributionOptions = { ...defaultAttributionOptions, ...config.attributionOptions };
+		this.scalebarOptions = { ...defaultScalebarOptions, ...config.scalebarOptions };
+		this.northIconOptions = { ...defaultNorthIconOptions, ...config.northIconOptions };
+	}
+
+	/** Class name of markers of the underlying library */
+	protected get markerClassName() {
+		return `${this.cssPrefix}-marker`;
+	}
+
+	/** Class name of the attribution control element of the underlying library */
+	protected get attributionClassName() {
+		return `${this.cssPrefix}-ctrl-attrib`;
+	}
+
+	/** Class name of the scale control element of the underlying library */
+	protected get scalebarClassName() {
+		return `${this.cssPrefix}-ctrl-scale`;
+	}
+
+	/** Ratio between the exported resolution and the base 96 DPI layout */
+	protected get scaleFactor() {
+		return this.dpi / 96;
 	}
 
 	protected abstract getRenderedMap(
 		container: HTMLElement,
 		style: StyleSpecification | mapboxgl.Style
 	): MaplibreMap | MapboxMap;
+
+	/**
+	 * Add a scale control to the hidden map. The control element is rasterized and
+	 * drawn on the exported canvas afterwards, so it only has to exist in the DOM.
+	 */
+	protected abstract addScaleControl(
+		renderMap: MaplibreMap | MapboxMap,
+		options: ScalebarOptions
+	): void;
+
+	/**
+	 * Add an attribution control to the hidden map. Its text is read from the DOM and
+	 * drawn on the exported canvas afterwards.
+	 */
+	protected abstract addAttributionControl(
+		renderMap: MaplibreMap | MapboxMap,
+		options: AttributionOptions
+	): void;
 
 	protected renderMapPost(renderMap: MaplibreMap | MapboxMap) {
 		return renderMap;
@@ -184,26 +241,28 @@ export abstract class MapGeneratorBase {
 	}
 
 	/**
-	 * Generate and download Map image
+	 * Generate and download Map image.
+	 *
+	 * The map is rendered on a hidden map object at the requested page size and DPI,
+	 * then its canvas is composed with the scale bar, north icon and attribution
+	 * onto a 2D canvas which is what actually gets exported.
 	 */
-	generate() {
-		// eslint-disable-next-line
-		const this_ = this;
-
+	async generate() {
 		this.addLoader();
 		this.showLoader();
 
 		// Calculate pixel ratio
 		const actualPixelRatio: number = window.devicePixelRatio;
 		Object.defineProperty(window, 'devicePixelRatio', {
-			get() {
-				return this_.dpi / 96;
-			}
+			get: () => this.scaleFactor,
+			configurable: true
 		});
+
 		// Create map container
 		const hidden = document.createElement('div');
 		hidden.className = 'hidden-map';
 		document.body.appendChild(hidden);
+		this.hiddenContainer = hidden;
 		const container = document.createElement('div');
 		container.style.width = this.toPixels(this.width);
 		container.style.height = this.toPixels(this.height);
@@ -222,286 +281,254 @@ export abstract class MapGeneratorBase {
 			});
 		}
 
-		// Render map
-		let renderMap = this.getRenderedMap(container, style) as MaplibreMap;
+		try {
+			// Render map
+			let renderMap = this.getRenderedMap(container, style) as MaplibreMap;
 
-		renderMap.on('load', () => {
-			this.addNorthIconToMap(renderMap).then(() => {
-				renderMap.once('idle', () => {
-					const isAttributionAdded = this.addAttributions(renderMap);
-					if (isAttributionAdded) {
-						renderMap.once('idle', () => {
-							renderMap = this.renderMapPost(renderMap) as MaplibreMap;
-							const markers = this.getMarkers();
-							if (markers.length === 0) {
-								this.exportImage(renderMap, hidden, actualPixelRatio);
-							} else {
-								renderMap = this.renderMarkers(renderMap) as MaplibreMap;
-								renderMap.once('idle', () => {
-									this.exportImage(renderMap, hidden, actualPixelRatio);
-								});
-							}
-						});
-					} else {
-						renderMap = this.renderMapPost(renderMap) as MaplibreMap;
-						const markers = this.getMarkers();
-						if (markers.length === 0) {
-							this.exportImage(renderMap, hidden, actualPixelRatio);
-						} else {
-							renderMap = this.renderMarkers(renderMap) as MaplibreMap;
-							renderMap.once('idle', () => {
-								this.exportImage(renderMap, hidden, actualPixelRatio);
-							});
-						}
-					}
-				});
+			await this.waitForEvent(renderMap, 'load', LOAD_TIMEOUT_MS);
+
+			renderMap = this.renderMapPost(renderMap) as MaplibreMap;
+
+			if (this.getMarkers().length > 0) {
+				renderMap = this.renderMarkers(renderMap) as MaplibreMap;
+			}
+
+			await this.waitForEvent(renderMap, 'idle', IDLE_TIMEOUT_MS);
+
+			const canvas = await this.composeCanvas(renderMap);
+			this.exportImage(canvas, renderMap);
+
+			renderMap.remove();
+		} catch (err) {
+			console.error('Failed to generate map image:', err);
+		} finally {
+			hidden.parentNode?.removeChild(hidden);
+			hidden.remove();
+			this.hiddenContainer = undefined;
+			Object.defineProperty(window, 'devicePixelRatio', {
+				get: () => actualPixelRatio,
+				configurable: true
 			});
-		});
-	}
-
-	private stripHtml(htmlString: string) {
-		const tempElement = document.createElement('div');
-		tempElement.innerHTML = htmlString;
-		return tempElement.textContent || tempElement.innerText || '';
-	}
-
-	/**
-	 * Get icon width against exported map size by using fraction rate
-	 * @param renderMap Map object
-	 * @param fraction adjust icon size by using this fraction rate. Default is 8%
-	 * @returns Icon width calculated
-	 */
-	private getIconWidth(renderMap: MaplibreMap | MapboxMap, fraction: number) {
-		const containerDiv = renderMap.getContainer();
-		const width = parseInt(containerDiv.style.width.replace('px', ''));
-		return parseInt(`${width * fraction}`);
-	}
-
-	/**
-	 * Get element position's pixel values based on selected position setting
-	 * @param renderMap Map object
-	 * @param position Position of element inserted
-	 * @param offset Offset value to adjust position
-	 * @returns Pixels [width, height]
-	 */
-	private getElementPosition(
-		renderMap: MaplibreMap | MapboxMap,
-		position: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right',
-		offset = 0
-	) {
-		const containerDiv = renderMap.getContainer();
-		let width = 0;
-		let height = 0;
-
-		switch (position) {
-			case 'top-left':
-				width = 0 + offset;
-				height = 0 + offset;
-				break;
-			case 'top-right':
-				width = parseInt(containerDiv.style.width.replace('px', '')) - offset;
-				height = 0 + offset;
-				break;
-			case 'bottom-left':
-				width = 0 + offset;
-				height = parseInt(containerDiv.style.height.replace('px', '')) - offset;
-				break;
-			case 'bottom-right':
-				width = parseInt(containerDiv.style.width.replace('px', '')) - offset;
-				height = parseInt(containerDiv.style.height.replace('px', '')) - offset;
-				break;
-			default:
-				break;
+			this.hideLoader();
 		}
-
-		const pixels: [number, number] = [width, height];
-		return pixels;
 	}
 
 	/**
-	 * Add North Icon SVG to map object
-	 * @param renderMap Map object
-	 * @returns void
+	 * Wait for an event of the hidden map, giving up after `timeoutMs`.
+	 *
+	 * Neither `load` nor `idle` is guaranteed to fire: a source which never finishes
+	 * loading keeps the style from being reported as loaded, and `idle` does not fire
+	 * when nothing has to be re-rendered. Exporting a partially rendered map is far
+	 * better than hanging forever, so the wait is always bounded.
 	 */
-	private addNorthIconImage(renderMap: MaplibreMap | MapboxMap) {
-		const iconSize = this.getIconWidth(renderMap, this.northIconOptions.imageSizeFraction ?? 0.08);
+	private waitForEvent(
+		renderMap: MaplibreMap | MapboxMap,
+		type: 'load' | 'idle',
+		timeoutMs: number
+	) {
 		return new Promise<void>((resolve) => {
-			const svgImage = new Image(iconSize, iconSize);
-			svgImage.onload = () => {
-				if (this.northIconOptions.imageName) {
-					renderMap.addImage(this.northIconOptions.imageName, svgImage);
+			let settled = false;
+			const finish = (timedOut = false) => {
+				if (settled) return;
+				settled = true;
+				if (timedOut) {
+					console.warn(`Timed out waiting for the '${type}' event of the map to be exported`);
 				}
 				resolve();
 			};
-			function svgStringToImageSrc(svgString: string) {
-				return 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svgString);
-			}
-			if (this.northIconOptions.image) {
-				svgImage.src = svgStringToImageSrc(this.northIconOptions.image);
-			}
+			(renderMap as MaplibreMap).once(type, () => finish());
+			setTimeout(() => finish(true), timeoutMs);
 		});
 	}
 
 	/**
-	 * Add North Icon Symbol layer to renderMap object
-	 * @param renderMap Map object
-	 * @returns
+	 * Compose the exported image from the rendered map canvas and the overlays.
+	 * @param renderMap hidden Map object which has finished rendering
+	 * @returns 2D canvas containing the final image
 	 */
-	private addNorthIconToMap(renderMap: MaplibreMap | MapboxMap) {
-		let visibility: 'visible' | 'none' = this.northIconOptions.visibility ?? 'visible';
-		if (renderMap.getZoom() < 2 && this.width > this.height) {
-			// if zoom level is less than 2, it will appear twice.
-			visibility = 'none';
-		}
-		return new Promise<void>((resolve) => {
-			this.addNorthIconImage(renderMap).then(() => {
-				const iconSize = this.getIconWidth(
-					renderMap,
-					this.northIconOptions.imageSizeFraction ?? 0.08
-				);
-				const iconOffset = iconSize * 0.8;
-				const pixels = this.getElementPosition(
-					renderMap,
-					this.northIconOptions.position ?? 'top-right',
-					iconOffset
-				);
-				const lngLat = (renderMap as MaplibreMap).unproject(pixels);
+	private async composeCanvas(renderMap: MaplibreMap | MapboxMap) {
+		const mapCanvas = renderMap.getCanvas();
 
-				const layerId = this.northIconOptions.imageName ?? 'gl-export-north-icon';
-				renderMap.addSource(layerId, {
-					type: 'geojson',
-					data: {
-						type: 'Feature',
-						geometry: {
-							type: 'Point',
-							coordinates: [lngLat.lng, lngLat.lat]
-						},
-						properties: {}
-					}
-				});
+		const canvas = document.createElement('canvas');
+		canvas.width = mapCanvas.width;
+		canvas.height = mapCanvas.height;
 
-				(renderMap as MapboxMap).addLayer({
-					id: layerId,
-					source: layerId,
-					type: 'symbol',
-					layout: {
-						'icon-image': layerId,
-						'icon-size': 1.0,
-						'icon-rotate': renderMap.getBearing() * -1,
-						'icon-allow-overlap': true,
-						'icon-ignore-placement': true,
-						visibility: visibility
-					},
-					paint: {}
-				});
-				resolve();
-			});
-		});
+		const ctx = canvas.getContext('2d');
+		if (!ctx) throw new Error('Failed to get 2D context for the export canvas');
+
+		// fill white first, otherwise transparent areas turn black in JPEG
+		ctx.fillStyle = '#ffffff';
+		ctx.fillRect(0, 0, canvas.width, canvas.height);
+		ctx.imageSmoothingEnabled = true;
+		ctx.imageSmoothingQuality = 'high';
+		ctx.drawImage(mapCanvas, 0, 0);
+
+		// attribution is drawn first because the scale bar is stacked on top of it
+		// when both are placed in the same corner.
+		const attributionBox = await this.drawAttribution(ctx, canvas);
+		await this.drawScalebar(ctx, canvas, attributionBox);
+		await this.drawNorthIcon(ctx, canvas, renderMap.getBearing());
+
+		return canvas;
 	}
 
-	private addAttributions(renderMap: MaplibreMap | MapboxMap) {
-		const glyphs = this.map.getStyle().glyphs;
-		// skip if glyphs is not available in style.
-		if (!glyphs) return false;
-
-		const containerDiv = renderMap.getContainer();
-		const elementPosition = this.attributionOptions.position ?? 'bottom-right';
-		const pixels = this.getElementPosition(renderMap, elementPosition, 5);
-		const width = pixels[0];
-		const lngLat = (renderMap as MaplibreMap).unproject(pixels);
-
-		const attrElements = containerDiv.getElementsByClassName(this.attributionClassName);
-		const attributions: string[] = [];
-		if (attrElements?.length > 0) {
-			// try getting attribution from html elements
-			const attrs = attrElements.item(0);
-			if (attrs) {
-				for (let i = 0; i < attrs.children.length; i++) {
-					const child = attrs.children.item(i);
-					if (!child) continue;
-					attributions.push(this.stripHtml(child.outerHTML));
-				}
-			}
-		} else {
-			// if not, try to make attribution from style
-			const sources = this.map.getStyle().sources;
-			Object.keys(sources).forEach((key) => {
-				const src: SourceSpecification = sources[key] as SourceSpecification;
-				if ('attribution' in src) {
-					const attribution = src.attribution as string;
-					attributions.push(this.stripHtml(attribution));
-				}
-			});
-		}
-
-		if (attributions.length === 0) return false;
-
-		const attributionText = attributions.join(' | ');
-
-		const attributionId = `attribution`;
-		renderMap.addSource(attributionId, {
-			type: 'geojson',
-			data: {
-				type: 'Feature',
-				geometry: {
-					type: 'Point',
-					coordinates: [lngLat.lng, lngLat.lat]
-				},
-				properties: {
-					attribution: attributionText
-				}
-			}
-		});
-
-		const fontLayers = this.map
-			.getStyle()
-			.layers.filter(
-				(l) => l.type === 'symbol' && l.layout && 'text-font' in l.layout
-			) as SymbolLayerSpecification[];
-		const font: string[] =
-			fontLayers.length > 0 && fontLayers[0].layout
-				? (fontLayers[0].layout['text-font'] as string[])
-				: (this.attributionOptions.style?.fallbackTextFont as string[]);
-
-		let visibility: 'visible' | 'none' = this.attributionOptions.visibility ?? 'visible';
-		if (renderMap.getZoom() < 2 && this.width > this.height) {
-			// if zoom level is less than 2, it will appear twice.
-			visibility = 'none';
-		}
-
-		const attrStyle = this.attributionOptions.style as AttributionStyle;
-
-		(renderMap as MapboxMap).addLayer({
-			id: attributionId,
-			source: attributionId,
-			type: 'symbol',
-			layout: {
-				'text-field': ['get', 'attribution'],
-				'text-font': font,
-				'text-max-width': parseInt(`${width / attrStyle.textSize}`),
-				'text-anchor': elementPosition,
-				'text-justify': ['top-right', 'bottom-right'].includes(elementPosition) ? 'right' : 'left',
-				'text-size': attrStyle.textSize,
-				'text-allow-overlap': true,
-				visibility: visibility
-			},
-			paint: {
-				'text-halo-color': attrStyle.textHaloColor,
-				'text-halo-width': attrStyle.textHaloWidth,
-				'text-color': attrStyle.textColor
-			}
-		});
-
-		return true;
-	}
-
-	private exportImage(
-		renderMap: MaplibreMap | MapboxMap,
-		hiddenDiv: HTMLElement,
-		actualPixelRatio: number
+	/**
+	 * Calculate the top-left corner where an overlay of the given size is drawn.
+	 * @param canvas export canvas
+	 * @param position corner of the canvas
+	 * @param width overlay width in export pixels
+	 * @param height overlay height in export pixels
+	 * @param margin distance from the canvas edge in export pixels
+	 */
+	private getOverlayOrigin(
+		canvas: HTMLCanvasElement,
+		position: ControlPosition,
+		width: number,
+		height: number,
+		margin: number
 	) {
-		const canvas = renderMap.getCanvas();
+		const left = ['top-left', 'bottom-left'].includes(position);
+		const top = ['top-left', 'top-right'].includes(position);
+		return {
+			x: left ? margin : canvas.width - width - margin,
+			y: top ? margin : canvas.height - height - margin
+		};
+	}
 
+	/**
+	 * Rasterize the attribution control element of the hidden map and draw it on the export canvas.
+	 * The native maplibre control element is used as-is, so it keeps its own styling.
+	 * @returns the box occupied by the attribution, or undefined when nothing was drawn
+	 */
+	private async drawAttribution(ctx: CanvasRenderingContext2D, canvas: HTMLCanvasElement) {
+		if (this.attributionOptions.visibility === 'none') return;
+
+		try {
+			const element = this.hiddenContainer
+				?.getElementsByClassName(this.attributionClassName)
+				?.item(0) as HTMLElement | null;
+			if (!element || element.offsetWidth === 0) return;
+
+			// `skipFonts` avoids html-to-image walking document.styleSheets to embed @font-face
+			// rules, which throws a SecurityError on cross-origin stylesheets. Fonts already
+			// loaded in the document still render during rasterization.
+			const attributionCanvas = await toCanvas(element, {
+				pixelRatio: this.scaleFactor,
+				skipFonts: true
+			});
+			if (attributionCanvas.width === 0 || attributionCanvas.height === 0) return;
+
+			const position = this.attributionOptions.position ?? 'bottom-right';
+			const margin = (this.attributionOptions.margin ?? 10) * this.scaleFactor;
+			const { x, y } = this.getOverlayOrigin(
+				canvas,
+				position,
+				attributionCanvas.width,
+				attributionCanvas.height,
+				margin
+			);
+
+			ctx.drawImage(attributionCanvas, x, y);
+
+			return { x, y, width: attributionCanvas.width, height: attributionCanvas.height };
+		} catch (err) {
+			console.warn('Failed to render attribution:', err);
+		}
+	}
+
+	/**
+	 * Rasterize the scale control element of the hidden map and draw it on the export canvas.
+	 * @param attributionBox box of the attribution, used to avoid overlapping it
+	 */
+	private async drawScalebar(
+		ctx: CanvasRenderingContext2D,
+		canvas: HTMLCanvasElement,
+		attributionBox?: { x: number; y: number; width: number; height: number }
+	) {
+		if (this.scalebarOptions.visibility === 'none') return;
+
+		try {
+			const element = this.hiddenContainer
+				?.getElementsByClassName(this.scalebarClassName)
+				?.item(0) as HTMLElement | null;
+			if (!element || element.offsetWidth === 0) return;
+
+			// `skipFonts` avoids html-to-image walking document.styleSheets to embed @font-face
+			// rules, which throws a SecurityError on cross-origin stylesheets. Fonts already
+			// loaded in the document still render during rasterization.
+			const scalebarCanvas = await toCanvas(element, {
+				pixelRatio: this.scaleFactor,
+				skipFonts: true
+			});
+			if (scalebarCanvas.width === 0 || scalebarCanvas.height === 0) return;
+
+			const position = this.scalebarOptions.position ?? 'bottom-left';
+			const margin = (this.scalebarOptions.margin ?? 10) * this.scaleFactor;
+			const origin = this.getOverlayOrigin(
+				canvas,
+				position,
+				scalebarCanvas.width,
+				scalebarCanvas.height,
+				margin
+			);
+
+			// stack the scale bar on top of / below the attribution when they share a corner
+			let { y } = origin;
+			if (attributionBox && this.attributionOptions.position === position) {
+				y = position.startsWith('top')
+					? attributionBox.y + attributionBox.height + margin
+					: attributionBox.y - scalebarCanvas.height - margin;
+			}
+
+			ctx.drawImage(scalebarCanvas, origin.x, y);
+		} catch (err) {
+			console.warn('Failed to render scale bar:', err);
+		}
+	}
+
+	/**
+	 * Draw the north icon on the export canvas, rotated to match the map bearing.
+	 * @param bearing bearing of the rendered map in degrees
+	 */
+	private async drawNorthIcon(
+		ctx: CanvasRenderingContext2D,
+		canvas: HTMLCanvasElement,
+		bearing: number
+	) {
+		if (this.northIconOptions.visibility === 'none') return;
+		const svg = this.northIconOptions.image;
+		if (!svg) return;
+
+		try {
+			const size = canvas.width * (this.northIconOptions.imageSizeFraction ?? 0.05);
+			const image = await new Promise<HTMLImageElement>((resolve, reject) => {
+				const img = new Image(size, size);
+				img.onload = () => resolve(img);
+				img.onerror = () => reject(new Error('Failed to load the north icon image'));
+				img.src = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+			});
+
+			const margin = (this.northIconOptions.margin ?? 10) * this.scaleFactor;
+			const { x, y } = this.getOverlayOrigin(
+				canvas,
+				this.northIconOptions.position ?? 'top-right',
+				size,
+				size,
+				margin
+			);
+
+			ctx.save();
+			ctx.translate(x + size / 2, y + size / 2);
+			// the map is rotated clockwise by `bearing`, so north sits counter-clockwise by the same angle
+			ctx.rotate((-bearing * Math.PI) / 180);
+			ctx.drawImage(image, -size / 2, -size / 2, size, size);
+			ctx.restore();
+		} catch (err) {
+			console.warn('Failed to render north icon:', err);
+		}
+	}
+
+	private exportImage(canvas: HTMLCanvasElement, renderMap: MaplibreMap | MapboxMap) {
 		const fileName = `${this.fileName}.${this.format}`;
 		switch (this.format) {
 			case Format.PNG:
@@ -511,7 +538,7 @@ export abstract class MapGeneratorBase {
 				this.toJPEG(canvas, fileName);
 				break;
 			case Format.PDF:
-				this.toPDF(renderMap, fileName);
+				this.toPDF(canvas, renderMap, fileName);
 				break;
 			case Format.SVG:
 				this.toSVG(canvas, fileName);
@@ -520,17 +547,6 @@ export abstract class MapGeneratorBase {
 				console.error(`Invalid file format: ${this.format}`);
 				break;
 		}
-
-		renderMap.remove();
-		hiddenDiv.parentNode?.removeChild(hiddenDiv);
-		Object.defineProperty(window, 'devicePixelRatio', {
-			get() {
-				return actualPixelRatio;
-			}
-		});
-		hiddenDiv.remove();
-
-		this.hideLoader();
 	}
 
 	/**
@@ -561,12 +577,12 @@ export abstract class MapGeneratorBase {
 	}
 
 	/**
-	 * Convert Map object to PDF
-	 * @param map Map object
+	 * Convert canvas to PDF
+	 * @param canvas composed Canvas element
+	 * @param map Map object used to read the document properties
 	 * @param fileName file name
 	 */
-	private toPDF(map: MaplibreMap | MapboxMap, fileName: string) {
-		const canvas = map.getCanvas();
+	private toPDF(canvas: HTMLCanvasElement, map: MaplibreMap | MapboxMap, fileName: string) {
 		const pdf = new jsPDF({
 			orientation: this.width > this.height ? 'l' : 'p',
 			unit: this.unit,
@@ -608,14 +624,14 @@ export abstract class MapGeneratorBase {
 		const pxHeight = Number(this.toPixels(this.height, this.dpi).replace('px', ''));
 
 		const svg = `
-    <svg xmlns="http://www.w3.org/2000/svg" 
-      xmlns:xlink="http://www.w3.org/1999/xlink" 
-      version="1.1" 
-      width="${pxWidth}" 
-      height="${pxHeight}" 
-      viewBox="0 0 ${pxWidth} ${pxHeight}" 
+    <svg xmlns="http://www.w3.org/2000/svg"
+      xmlns:xlink="http://www.w3.org/1999/xlink"
+      version="1.1"
+      width="${pxWidth}"
+      height="${pxHeight}"
+      viewBox="0 0 ${pxWidth} ${pxHeight}"
       xml:space="preserve">
-        <image style="stroke: none; stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;"  
+        <image style="stroke: none; stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(0,0,0); fill-rule: nonzero; opacity: 1;"
       xlink:href="${uri}" width="${pxWidth}" height="${pxHeight}"></image>
     </svg>`;
 

--- a/packages/maplibre-gl-export/src/lib/map-generator.ts
+++ b/packages/maplibre-gl-export/src/lib/map-generator.ts
@@ -1,46 +1,21 @@
-import { Map as MaplibreMap, StyleSpecification } from 'maplibre-gl';
-import { DPIType, Format, FormatType, Size, SizeType, Unit, UnitType } from './interfaces';
 import {
-	MapGeneratorBase,
-	defaultAttributionOptions,
-	defaultMarkerCirclePaint,
-	defaultNorthIconOptions
-} from './map-generator-base';
+	AttributionControl,
+	ControlPosition,
+	Map as MaplibreMap,
+	ScaleControl,
+	StyleSpecification
+} from 'maplibre-gl';
+import { AttributionOptions, ScalebarOptions } from './interfaces';
+import { MapGeneratorBase, MapGeneratorConfig } from './map-generator-base';
 
 export default class MapGenerator extends MapGeneratorBase {
 	/**
 	 * Constructor
 	 * @param map MaplibreMap object
-	 * @param size layout size. default is A4
-	 * @param dpi dpi value. default is 300
-	 * @param format image format. default is PNG
-	 * @param unit length unit. default is mm
-	 * @param fileName file name. default is 'map'
+	 * @param config generator settings. See {@link MapGeneratorConfig}
 	 */
-	constructor(
-		map: MaplibreMap,
-		size: SizeType = Size.A4,
-		dpi: DPIType = 300,
-		format: FormatType = Format.PNG,
-		unit: UnitType = Unit.mm,
-		fileName = 'map',
-		markerCirclePaint = defaultMarkerCirclePaint,
-		attributionOptions = defaultAttributionOptions,
-		northIconOptions = defaultNorthIconOptions
-	) {
-		super(
-			map,
-			size,
-			dpi,
-			format,
-			unit,
-			fileName,
-			'maplibregl-marker',
-			markerCirclePaint,
-			'maplibregl-ctrl-attrib-inner',
-			attributionOptions,
-			northIconOptions
-		);
+	constructor(map: MaplibreMap, config: MapGeneratorConfig = {}) {
+		super(map, { ...config, cssPrefix: 'maplibregl' });
 	}
 
 	protected getRenderedMap(container: HTMLElement, style: StyleSpecification) {
@@ -57,7 +32,8 @@ export default class MapGenerator extends MapGeneratorBase {
 				preserveDrawingBuffer: true
 			},
 			fadeDuration: 0,
-			// attributionControl: false,
+			// the attribution control is added explicitly below so that its options can be controlled
+			attributionControl: false,
 			// hack to read transform request callback function
 			// eslint-disable-next-line
 			// @ts-ignore
@@ -78,7 +54,27 @@ export default class MapGenerator extends MapGeneratorBase {
 			renderMap.addImage(key, images[key].data);
 		});
 
+		this.addScaleControl(renderMap, this.scalebarOptions);
+		this.addAttributionControl(renderMap, this.attributionOptions);
+
 		return renderMap;
+	}
+
+	protected addScaleControl(renderMap: MaplibreMap, options: ScalebarOptions) {
+		if (options.visibility === 'none') return;
+		const control = new ScaleControl({ maxWidth: options.maxWidth, unit: options.unit });
+		renderMap.addControl(control, (options.position ?? 'bottom-left') as ControlPosition);
+	}
+
+	protected addAttributionControl(renderMap: MaplibreMap, options: AttributionOptions) {
+		if (options.visibility === 'none') return;
+		const control = new AttributionControl({
+			customAttribution: options.customAttribution,
+			// never collapse. the responsive default hides the text on maps narrower than 640px,
+			// which happens for smaller page sizes.
+			compact: false
+		});
+		renderMap.addControl(control, (options.position ?? 'bottom-right') as ControlPosition);
 	}
 
 	protected renderMapPost(renderMap: MaplibreMap) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      html-to-image:
+        specifier: ^1.11.13
+        version: 1.11.13
     devDependencies:
       '@changesets/cli':
         specifier: ^2.31.1
@@ -87,6 +91,9 @@ importers:
 
   packages/maplibre-gl-export:
     dependencies:
+      html-to-image:
+        specifier: ^1.11.13
+        version: 1.11.13
       jspdf:
         specifier: ^4.2.1
         version: 4.2.1
@@ -1834,6 +1841,9 @@ packages:
 
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  html-to-image@1.11.13:
+    resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
@@ -5178,6 +5188,8 @@ snapshots:
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.5
+
+  html-to-image@1.11.13: {}
 
   html-void-elements@3.0.0: {}
 

--- a/sites/demo/src/routes/+page.svelte
+++ b/sites/demo/src/routes/+page.svelte
@@ -6,7 +6,8 @@
 		Languages,
 		defaultAttributionOptions,
 		defaultMarkerCirclePaint,
-		defaultNorthIconOptions
+		defaultNorthIconOptions,
+		defaultScalebarOptions
 	} from '@watergis/maplibre-gl-export';
 	import type { PageData } from './$types';
 	import CodeBlock from '$lib/CodeBlock.svelte';
@@ -96,8 +97,7 @@
 		mapboxCdnExample = await res.text();
 	};
 
-	const northOptions = defaultNorthIconOptions;
-	northOptions.image = 'bring your own SVG string';
+	const northOptions = { ...defaultNorthIconOptions, image: 'bring your own SVG string' };
 
 	const parameters = [
 		{
@@ -172,13 +172,19 @@
 			name: 'attributionOptions',
 			default: JSON.stringify(defaultAttributionOptions, null, 2),
 			description:
-				'This plugin will try to add attribution to the bottom-right or top-right of the image as a maplibre symbol layer. The default style of attribution label can be changed per your preference. For fallbackTextFont property, it will only be used when font information cannot be fetched from style object. If glyphs property is not set to your style object, attribution will not be added. You can hide it if none is set to visibility.'
+				"An `AttributionControl` is added to the hidden map used for rendering, and its element is drawn onto the exported image keeping maplibre's native styling. `compact` and `customAttribution` of maplibre's `AttributionControlOptions` can be set here, in addition to `position` and `margin`. It can be placed in any of the four corners. Set `visibility` to `none` to hide it."
+		},
+		{
+			name: 'scalebarOptions',
+			default: JSON.stringify(defaultScalebarOptions, null, 2),
+			description:
+				"A `ScaleControl` is added to the hidden map used for rendering, and its element is drawn onto the exported image. `maxWidth` and `unit` of maplibre's `ScaleControlOptions` can be set here, in addition to `position` and `margin`. Set `visibility` to `none` to hide it. It can also be toggled from the export panel."
 		},
 		{
 			name: 'northIconOptions',
 			default: JSON.stringify(northOptions, null, 2),
 			description:
-				'North icon options. It is shown at top-right of corner of exported map as default. The size of north icon is 5% of map width. You can customize icon image and other settings through this option. North icon is not rendered when zoom level is less than 2 and landscape mode since it appears twice.'
+				'North icon options. It is drawn onto the exported image at the top-right corner as default, rotated to match the map bearing. The size of north icon is 5% of map width. You can customize icon image and other settings through this option. It can also be toggled from the export panel.'
 		},
 		{
 			name: 'accessToken',

--- a/sites/demo/src/routes/maplibre/+page.svelte
+++ b/sites/demo/src/routes/maplibre/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import {
 		addProtocol,
+		GlobeControl,
 		Map,
 		Marker,
 		NavigationControl,
@@ -70,6 +71,7 @@
 		});
 
 		map.addControl(new NavigationControl({ visualizePitch: true }), 'bottom-right');
+		map.addControl(new GlobeControl(), 'bottom-right');
 
 		new Marker().setLngLat([37.30467, -0.15943]).addTo(map);
 		new Marker().setLngLat([30.0824, -1.9385]).addTo(map);


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

feat: draw the attribution, north icon and a new scale bar onto the exported image with a composed 2D canvas instead of adding them as symbol layers.

The exported map canvas is now composed onto a 2D canvas before being saved, and the overlays are drawn on top of it. A `ScaleControl` and an `AttributionControl` are added to the hidden map used for rendering, and their elements are rasterized and drawn onto the exported image, keeping maplibre's native styling. This removes the limitations of the previous symbol layer approach:

- the attribution no longer requires the `glyphs` property in the style
- the attribution and the north icon are no longer hidden at zoom levels below 2
- the attribution can now be placed in any of the four corners
- a scale bar is exported for the first time, and can be toggled from the export panel together with the north icon

### Usage

The scale bar and north icon can be toggled from the export panel, and both overlays can be configured through `MaplibreExportControl`:

```ts
import { MaplibreExportControl, Size, PageOrientation, Format, DPI } from '@watergis/maplibre-gl-export';

const exportControl = new MaplibreExportControl({
  PageSize: Size.A3,
  PageOrientation: PageOrientation.Landscape,
  Format: Format.PNG,
  DPI: DPI[300],
  // attribution: rasterized from maplibre's own AttributionControl (keeps native styling)
  attributionOptions: {
    visibility: 'visible',
    position: 'bottom-right', // any of the four corners
    margin: 10, // distance from the map edge at 96 DPI
    compact: false,
    customAttribution: '© My Company'
  },
  // scale bar: exported for the first time
  scalebarOptions: {
    visibility: 'visible',
    position: 'bottom-left',
    margin: 10,
    maxWidth: 100,
    unit: 'metric' // 'metric' | 'imperial' | 'nautical'
  },
  // north icon
  northIconOptions: {
    visibility: 'visible',
    position: 'top-right',
    margin: 10
  }
});

map.addControl(exportControl, 'top-right');
```

### Breaking changes

`attributionOptions.style` (`textSize`, `textColor`, `textHaloColor`, `textHaloWidth`, `fallbackTextFont`) has been removed. The attribution is now rasterized from maplibre's own `AttributionControl` element, so it keeps the library's native styling and there is nothing to configure. `attributionOptions` now accepts `compact` and `customAttribution` of maplibre's `AttributionControlOptions`, plus `visibility`, `position` (any of the four corners) and `margin`.

## Plugin

Select a plugin related to this PR.

- [x] maplibre-gl-export
- [x] mapbox-gl-export

## Type of Pull Request
<!-- ignore-task-list-start -->
- [x] Adding a feature
- [ ] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings
<!-- ignore-task-list-start -->
- [x] Code is up-to-date with the `main` branch
- [x] No lint errors after `pnpm lint`
- [x] Make sure all the existing features working well
- [x] Make sure a changeset file is added if your PR changes package code
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/watergis/maplibre-gl-export/tree/master/CONTRIBUTING.md) for more details.
