### PR TITLE
feat: add custom to PageSize menu to allow users to change height and width freely

### DIFF
--- a/.changeset/giant-times-grow.md
+++ b/.changeset/giant-times-grow.md
@@ -1,0 +1,6 @@
+---
+"@watergis/maplibre-gl-export": minor
+"@watergis/mapbox-gl-export": minor
+---
+
+feat: add custom to PageSize menu to allow users to change height and width freely,

--- a/.changeset/goofy-emus-push.md
+++ b/.changeset/goofy-emus-push.md
@@ -1,0 +1,6 @@
+---
+"@watergis/maplibre-gl-export": patch
+"@watergis/mapbox-gl-export": patch
+---
+
+fix: fixed form layout collapse, make it look better.

--- a/packages/mapbox-gl-export/src/scss/mapbox-gl-export.scss
+++ b/packages/mapbox-gl-export/src/scss/mapbox-gl-export.scss
@@ -1,5 +1,20 @@
 .mapboxgl-export-list {
 	display: none;
+	// the table below adds its own outer spacing through `border-spacing`
+	padding: 4px;
+}
+
+.mapboxgl-export-list .print-table {
+	// `separate` is required for `border-spacing`: it gives every column/row the same
+	// gutter so the labels and inputs are not cramped against each other.
+	border-collapse: separate;
+	border-spacing: 10px 6px;
+
+	td {
+		padding: 0;
+		vertical-align: middle;
+		white-space: nowrap;
+	}
 }
 
 .mapboxgl-ctrl-group .mapboxgl-export-list button {
@@ -32,6 +47,24 @@
 	background-position: center;
 	background-repeat: no-repeat;
 	background-size: 70%;
+}
+
+.mapboxgl-export-custom-size {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+
+	input {
+		// wide enough for ~4 digits so the panel keeps the preset layout width
+		width: 4em;
+		flex: none;
+		min-width: 0;
+	}
+
+	.mapboxgl-export-unit {
+		flex: none;
+		font-size: 12px;
+	}
 }
 
 /*

--- a/packages/maplibre-gl-export/index.ts
+++ b/packages/maplibre-gl-export/index.ts
@@ -60,6 +60,10 @@ map.addControl(
 	'top-right'
 );
 
+// eslint-disable-next-line
+// @ts-ignore
+window.__map = map;
+
 map.once('load', () => {
 	new Marker().setLngLat([37.30467, -0.15943]).addTo(map);
 

--- a/packages/maplibre-gl-export/src/lib/export-control.ts
+++ b/packages/maplibre-gl-export/src/lib/export-control.ts
@@ -509,11 +509,11 @@ export default class MaplibreExportControl implements IControl {
 			input.setAttribute('name', type);
 
 			const unit = document.createElement('span');
-			unit.className = 'maplibregl-export-unit';
+			unit.className = `${this.MAPLIB_CSS_PREFIX}-export-unit`;
 			unit.textContent = 'mm';
 
 			const wrapper = document.createElement('div');
-			wrapper.className = 'maplibregl-export-custom-size';
+			wrapper.className = `${this.MAPLIB_CSS_PREFIX}-export-custom-size`;
 			wrapper.appendChild(input);
 			wrapper.appendChild(unit);
 

--- a/packages/maplibre-gl-export/src/lib/export-control.ts
+++ b/packages/maplibre-gl-export/src/lib/export-control.ts
@@ -178,7 +178,7 @@ export default class MaplibreExportControl implements IControl {
 		};
 
 		// show the custom inputs only for the "Custom" entry. Orientation is meaningless then
-		// because the two inputs already define both dimensions, so disable it. Switching to
+		// because the two inputs already define both dimensions, so hide its row. Switching to
 		// "Custom" prefills the inputs from the last selected preset (oriented), so the user
 		// starts from the size they were just looking at.
 		let lastPresetValue = pageSizeSelect.value;
@@ -196,7 +196,7 @@ export default class MaplibreExportControl implements IControl {
 			customRows.forEach((row) => {
 				row.style.display = isCustom ? '' : 'none';
 			});
-			pageOrientationSelect.disabled = isCustom;
+			tr2.style.display = isCustom ? 'none' : '';
 			this.updatePrintableArea();
 		};
 		pageSizeSelect.addEventListener('change', syncCustomSize);

--- a/packages/maplibre-gl-export/src/lib/export-control.ts
+++ b/packages/maplibre-gl-export/src/lib/export-control.ts
@@ -26,6 +26,13 @@ import {
 } from './map-generator-base';
 
 /**
+ * Sentinel value of the page-size `<select>` option that switches the control to the
+ * user-entered custom width/height inputs. It is intentionally not valid JSON so it can
+ * never be confused with a serialized `[width, height]` preset tuple.
+ */
+const CUSTOM_SIZE_VALUE = 'custom';
+
+/**
  * MapLibre GL Export Control.
  * @param {Object} targets - Object of layer.id and title
  */
@@ -128,7 +135,20 @@ export default class MaplibreExportControl implements IControl {
 			this.options.PageSize as [number, number],
 			(data: { [key: string]: unknown }, key) => JSON.stringify(data[key])
 		);
+		// add a "Custom" entry so the end-user can type an arbitrary width/height (see below)
+		const pageSizeSelect = tr1.querySelector('select') as HTMLSelectElement;
+		const customOption = document.createElement('option');
+		customOption.value = CUSTOM_SIZE_VALUE;
+		customOption.textContent = this.getTranslation().Custom;
+		pageSizeSelect.appendChild(customOption);
 		table.appendChild(tr1);
+
+		// custom width/height inputs, prefilled from the default page size and hidden until
+		// the "Custom" entry is selected. Width and Height are separate rows so the panel
+		// keeps the same width as the preset layout.
+		const defaultSize = (this.options.PageSize as [number, number]) ?? Size.A4;
+		const { rows: customRows, widthInput, heightInput } = this.createCustomSizeRows(defaultSize);
+		customRows.forEach((row) => table.appendChild(row));
 
 		const tr2 = this.createSelection(
 			PageOrientation,
@@ -137,7 +157,52 @@ export default class MaplibreExportControl implements IControl {
 			this.options.PageOrientation as string,
 			(data: { [key: string]: unknown }, key) => data[key]
 		);
+		const pageOrientationSelect = tr2.querySelector('select') as HTMLSelectElement;
 		table.appendChild(tr2);
+
+		// resolve a preset `<option>` value (a JSON `[long, short]` tuple) into an oriented
+		// `[width, height]` tuple using the current orientation dropdown.
+		const resolvePresetSize = (value: string): [number, number] | null => {
+			if (!value || value === CUSTOM_SIZE_VALUE) {
+				return null;
+			}
+			let size: [number, number];
+			try {
+				size = JSON.parse(value) as [number, number];
+			} catch {
+				return null;
+			}
+			return pageOrientationSelect.value === PageOrientation.Portrait
+				? [size[1], size[0]]
+				: [size[0], size[1]];
+		};
+
+		// show the custom inputs only for the "Custom" entry. Orientation is meaningless then
+		// because the two inputs already define both dimensions, so disable it. Switching to
+		// "Custom" prefills the inputs from the last selected preset (oriented), so the user
+		// starts from the size they were just looking at.
+		let lastPresetValue = pageSizeSelect.value;
+		const syncCustomSize = () => {
+			const isCustom = pageSizeSelect.value === CUSTOM_SIZE_VALUE;
+			if (isCustom) {
+				const size = resolvePresetSize(lastPresetValue);
+				if (size) {
+					widthInput.value = String(size[0]);
+					heightInput.value = String(size[1]);
+				}
+			} else {
+				lastPresetValue = pageSizeSelect.value;
+			}
+			customRows.forEach((row) => {
+				row.style.display = isCustom ? '' : 'none';
+			});
+			pageOrientationSelect.disabled = isCustom;
+			this.updatePrintableArea();
+		};
+		pageSizeSelect.addEventListener('change', syncCustomSize);
+		widthInput.addEventListener('input', () => this.updatePrintableArea());
+		heightInput.addEventListener('input', () => this.updatePrintableArea());
+		syncCustomSize();
 
 		const tr3 = this.createSelection(
 			Format,
@@ -178,12 +243,6 @@ export default class MaplibreExportControl implements IControl {
 		generateButton.textContent = this.getTranslation().Generate;
 		generateButton.classList.add('generate-button');
 		generateButton.addEventListener('click', () => {
-			const pageSize: HTMLSelectElement = <HTMLSelectElement>(
-				document.getElementById('mapbox-gl-export-page-size')
-			);
-			const pageOrientation: HTMLSelectElement = <HTMLSelectElement>(
-				document.getElementById('mapbox-gl-export-page-orientation')
-			);
 			const formatType: HTMLSelectElement = <HTMLSelectElement>(
 				document.getElementById('mapbox-gl-export-format-type')
 			);
@@ -196,10 +255,10 @@ export default class MaplibreExportControl implements IControl {
 			const northIcon: HTMLInputElement = <HTMLInputElement>(
 				document.getElementById('mapbox-gl-export-north-icon')
 			);
-			const orientValue = pageOrientation.value;
-			let pageSizeValue = JSON.parse(pageSize.value);
-			if (orientValue === PageOrientation.Portrait) {
-				pageSizeValue = pageSizeValue.reverse();
+			// abort when the custom size is empty/invalid so we never generate a 0-sized map
+			const pageSizeValue = this.getSelectedSize();
+			if (!pageSizeValue) {
+				return;
 			}
 
 			// reflect the panel toggles before generating so that `generateMap` (which is also
@@ -383,17 +442,94 @@ export default class MaplibreExportControl implements IControl {
 		if (this.printableArea === undefined) {
 			return;
 		}
+		const pageSizeValue = this.getSelectedSize();
+		if (!pageSizeValue) {
+			return;
+		}
+		this.printableArea.updateArea(pageSizeValue[0], pageSizeValue[1]);
+	}
+
+	/**
+	 * Read the currently selected page size as a `[width, height]` mm tuple.
+	 *
+	 * For a preset the orientation dropdown is applied by swapping the stored landscape
+	 * tuple. For the "Custom" entry the two number inputs are used verbatim (they already
+	 * define the orientation); `null` is returned when either value is missing or not a
+	 * positive number so callers can skip generating / previewing.
+	 */
+	private getSelectedSize(): [number, number] | null {
 		const pageSize: HTMLSelectElement = <HTMLSelectElement>(
 			document.getElementById('mapbox-gl-export-page-size')
 		);
+		if (pageSize?.value === CUSTOM_SIZE_VALUE) {
+			const widthInput: HTMLInputElement = <HTMLInputElement>(
+				document.getElementById('mapbox-gl-export-custom-width')
+			);
+			const heightInput: HTMLInputElement = <HTMLInputElement>(
+				document.getElementById('mapbox-gl-export-custom-height')
+			);
+			const width = Number(widthInput?.value);
+			const height = Number(heightInput?.value);
+			if (!Number.isFinite(width) || width <= 0 || !Number.isFinite(height) || height <= 0) {
+				return null;
+			}
+			return [width, height];
+		}
 		const pageOrientation: HTMLSelectElement = <HTMLSelectElement>(
 			document.getElementById('mapbox-gl-export-page-orientation')
 		);
-		const orientValue = pageOrientation.value;
-		let pageSizeValue = JSON.parse(pageSize.value);
-		if (orientValue === PageOrientation.Portrait) {
-			pageSizeValue = pageSizeValue.reverse();
+		const size = JSON.parse(pageSize.value) as [number, number];
+		if (pageOrientation?.value === PageOrientation.Portrait) {
+			return [size[1], size[0]];
 		}
-		this.printableArea.updateArea(pageSizeValue[0], pageSizeValue[1]);
+		return [size[0], size[1]];
+	}
+
+	/**
+	 * Build the two stacked table rows holding the custom width and height number inputs
+	 * (in mm). Each dimension is its own row so the panel keeps the preset layout width.
+	 * @param defaultSize `[width, height]` used to prefill the inputs
+	 */
+	private createCustomSizeRows(defaultSize: readonly [number, number]): {
+		rows: HTMLElement[];
+		widthInput: HTMLInputElement;
+		heightInput: HTMLInputElement;
+	} {
+		const createRow = (type: string, title: string, value: number) => {
+			const label = document.createElement('label');
+			label.textContent = title;
+			label.setAttribute('for', `mapbox-gl-export-${type}`);
+
+			const input = document.createElement('input');
+			input.type = 'number';
+			input.min = '1';
+			input.step = '1';
+			input.value = String(value);
+			input.setAttribute('id', `mapbox-gl-export-${type}`);
+			input.setAttribute('name', type);
+
+			const unit = document.createElement('span');
+			unit.className = 'maplibregl-export-unit';
+			unit.textContent = 'mm';
+
+			const wrapper = document.createElement('div');
+			wrapper.className = 'maplibregl-export-custom-size';
+			wrapper.appendChild(input);
+			wrapper.appendChild(unit);
+
+			const row = document.createElement('TR');
+			row.style.display = 'none';
+			const tdLabel = document.createElement('TD');
+			const tdContent = document.createElement('TD');
+			tdLabel.appendChild(label);
+			tdContent.appendChild(wrapper);
+			row.appendChild(tdLabel);
+			row.appendChild(tdContent);
+			return { row, input };
+		};
+
+		const width = createRow('custom-width', this.getTranslation().Width, defaultSize[0]);
+		const height = createRow('custom-height', this.getTranslation().Height, defaultSize[1]);
+		return { rows: [width.row, height.row], widthInput: width.input, heightInput: height.input };
 	}
 }

--- a/packages/maplibre-gl-export/src/lib/interfaces/Size.ts
+++ b/packages/maplibre-gl-export/src/lib/interfaces/Size.ts
@@ -17,4 +17,6 @@ export const Size = {
 	B5: [250, 176],
 	B6: [176, 125]
 } as const;
-export type SizeType = (typeof Size)[keyof typeof Size];
+// `[number, number]` rather than the union of the preset tuples above so that
+// user-entered custom sizes (see the export control) are also valid `SizeType`s.
+export type SizeType = readonly [number, number];

--- a/packages/maplibre-gl-export/src/lib/interfaces/Translation.ts
+++ b/packages/maplibre-gl-export/src/lib/interfaces/Translation.ts
@@ -6,6 +6,9 @@ export type Translation = {
 	Generate: string;
 	Scalebar: string;
 	NorthIcon: string;
+	Custom: string;
+	Width: string;
+	Height: string;
 	LanguageName: string;
 	LanguageCode: string;
 };

--- a/packages/maplibre-gl-export/src/lib/local/ca.ts
+++ b/packages/maplibre-gl-export/src/lib/local/ca.ts
@@ -8,6 +8,9 @@ const translation: Translation = {
 	Generate: 'Genera',
 	Scalebar: "Barra d'escala",
 	NorthIcon: 'Icona del nord',
+	Custom: 'Personalitzat',
+	Width: 'Amplada',
+	Height: 'Alçada',
 	LanguageName: 'Catalan',
 	LanguageCode: 'ca'
 };

--- a/packages/maplibre-gl-export/src/lib/local/de.ts
+++ b/packages/maplibre-gl-export/src/lib/local/de.ts
@@ -8,6 +8,9 @@ const translation: Translation = {
 	Generate: 'Erstellen',
 	Scalebar: 'Maßstabsleiste',
 	NorthIcon: 'Nordpfeil',
+	Custom: 'Benutzerdefiniert',
+	Width: 'Breite',
+	Height: 'Höhe',
 	LanguageName: 'Deutsch',
 	LanguageCode: 'de'
 };

--- a/packages/maplibre-gl-export/src/lib/local/en.ts
+++ b/packages/maplibre-gl-export/src/lib/local/en.ts
@@ -8,6 +8,9 @@ const translation: Translation = {
 	Generate: 'Generate',
 	Scalebar: 'Scale bar',
 	NorthIcon: 'North icon',
+	Custom: 'Custom',
+	Width: 'Width',
+	Height: 'Height',
 	LanguageName: 'English',
 	LanguageCode: 'en'
 };

--- a/packages/maplibre-gl-export/src/lib/local/es.ts
+++ b/packages/maplibre-gl-export/src/lib/local/es.ts
@@ -8,6 +8,9 @@ const translation: Translation = {
 	Generate: 'Generar',
 	Scalebar: 'Barra de escala',
 	NorthIcon: 'Icono del norte',
+	Custom: 'Personalizado',
+	Width: 'Ancho',
+	Height: 'Alto',
 	LanguageName: 'Española',
 	LanguageCode: 'es'
 };

--- a/packages/maplibre-gl-export/src/lib/local/fi.ts
+++ b/packages/maplibre-gl-export/src/lib/local/fi.ts
@@ -8,6 +8,9 @@ const translation: Translation = {
 	Generate: 'Generoi',
 	Scalebar: 'Mittakaava',
 	NorthIcon: 'Pohjoisnuoli',
+	Custom: 'Mukautettu',
+	Width: 'Leveys',
+	Height: 'Korkeus',
 	LanguageName: 'Suomalainen',
 	LanguageCode: 'fi'
 };

--- a/packages/maplibre-gl-export/src/lib/local/fr.ts
+++ b/packages/maplibre-gl-export/src/lib/local/fr.ts
@@ -8,6 +8,9 @@ const translation: Translation = {
 	Generate: 'Générer',
 	Scalebar: "Barre d'échelle",
 	NorthIcon: 'Flèche du nord',
+	Custom: 'Personnalisé',
+	Width: 'Largeur',
+	Height: 'Hauteur',
 	LanguageName: 'Français',
 	LanguageCode: 'fr'
 };

--- a/packages/maplibre-gl-export/src/lib/local/ja.ts
+++ b/packages/maplibre-gl-export/src/lib/local/ja.ts
@@ -8,6 +8,9 @@ const translation: Translation = {
 	Generate: '出力',
 	Scalebar: 'スケールバー',
 	NorthIcon: '方位記号',
+	Custom: 'カスタム',
+	Width: '幅',
+	Height: '高さ',
 	LanguageName: '日本語',
 	LanguageCode: 'ja'
 };

--- a/packages/maplibre-gl-export/src/lib/local/pt.ts
+++ b/packages/maplibre-gl-export/src/lib/local/pt.ts
@@ -8,6 +8,9 @@ const translation: Translation = {
 	Generate: 'Gerar',
 	Scalebar: 'Barra de escala',
 	NorthIcon: 'Ícone do norte',
+	Custom: 'Personalizado',
+	Width: 'Largura',
+	Height: 'Altura',
 	LanguageName: 'Português',
 	LanguageCode: 'pt'
 };

--- a/packages/maplibre-gl-export/src/lib/local/ru.ts
+++ b/packages/maplibre-gl-export/src/lib/local/ru.ts
@@ -8,6 +8,9 @@ const translation: Translation = {
 	Generate: 'Сгенерировать',
 	Scalebar: 'Масштабная линейка',
 	NorthIcon: 'Указатель севера',
+	Custom: 'Пользовательский',
+	Width: 'Ширина',
+	Height: 'Высота',
 	LanguageName: 'русский',
 	LanguageCode: 'ru'
 };

--- a/packages/maplibre-gl-export/src/lib/local/sv.ts
+++ b/packages/maplibre-gl-export/src/lib/local/sv.ts
@@ -8,6 +8,9 @@ const translation: Translation = {
 	Generate: 'Generera',
 	Scalebar: 'Skalstock',
 	NorthIcon: 'Norrpil',
+	Custom: 'Anpassad',
+	Width: 'Bredd',
+	Height: 'Höjd',
 	LanguageName: 'Svenska',
 	LanguageCode: 'sv'
 };

--- a/packages/maplibre-gl-export/src/lib/local/uk.ts
+++ b/packages/maplibre-gl-export/src/lib/local/uk.ts
@@ -8,6 +8,9 @@ const translation: Translation = {
 	Generate: 'Згенерувати',
 	Scalebar: 'Масштабна лінійка',
 	NorthIcon: 'Покажчик півночі',
+	Custom: 'Власний',
+	Width: 'Ширина',
+	Height: 'Висота',
 	LanguageName: 'українська',
 	LanguageCode: 'uk'
 };

--- a/packages/maplibre-gl-export/src/lib/local/vi.ts
+++ b/packages/maplibre-gl-export/src/lib/local/vi.ts
@@ -8,6 +8,9 @@ const translation: Translation = {
 	Generate: 'Tạo',
 	Scalebar: 'Thanh tỷ lệ',
 	NorthIcon: 'Biểu tượng hướng bắc',
+	Custom: 'Tùy chỉnh',
+	Width: 'Chiều rộng',
+	Height: 'Chiều cao',
 	LanguageName: 'Tiếng Việt',
 	LanguageCode: 'vi'
 };

--- a/packages/maplibre-gl-export/src/lib/local/zhHans.ts
+++ b/packages/maplibre-gl-export/src/lib/local/zhHans.ts
@@ -8,6 +8,9 @@ const translation: Translation = {
 	Generate: '导出',
 	Scalebar: '比例尺',
 	NorthIcon: '指北针',
+	Custom: '自定义',
+	Width: '宽度',
+	Height: '高度',
 	LanguageName: '简体字',
 	LanguageCode: 'zhHans'
 };

--- a/packages/maplibre-gl-export/src/lib/local/zhHant.ts
+++ b/packages/maplibre-gl-export/src/lib/local/zhHant.ts
@@ -8,6 +8,9 @@ const translation: Translation = {
 	Generate: '導出',
 	Scalebar: '比例尺',
 	NorthIcon: '指北針',
+	Custom: '自訂',
+	Width: '寬度',
+	Height: '高度',
 	LanguageName: '繁体字',
 	LanguageCode: 'zhHant'
 };

--- a/packages/maplibre-gl-export/src/scss/maplibre-gl-export.scss
+++ b/packages/maplibre-gl-export/src/scss/maplibre-gl-export.scss
@@ -1,6 +1,20 @@
 .maplibregl-export-list {
 	display: none;
-	padding: 8px;
+	// the table below adds its own outer spacing through `border-spacing`
+	padding: 4px;
+}
+
+.maplibregl-export-list .print-table {
+	// `separate` is required for `border-spacing`: it gives every column/row the same
+	// gutter so the labels and inputs are not cramped against each other.
+	border-collapse: separate;
+	border-spacing: 10px 6px;
+
+	td {
+		padding: 0;
+		vertical-align: middle;
+		white-space: nowrap;
+	}
 }
 
 .maplibregl-ctrl-group .maplibregl-export-list button {

--- a/packages/maplibre-gl-export/src/scss/maplibre-gl-export.scss
+++ b/packages/maplibre-gl-export/src/scss/maplibre-gl-export.scss
@@ -1,5 +1,6 @@
 .maplibregl-export-list {
 	display: none;
+	padding: 8px;
 }
 
 .maplibregl-ctrl-group .maplibregl-export-list button {
@@ -32,6 +33,24 @@
 	background-position: center;
 	background-repeat: no-repeat;
 	background-size: 70%;
+}
+
+.maplibregl-export-custom-size {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+
+	input {
+		// wide enough for ~4 digits so the panel keeps the preset layout width
+		width: 4em;
+		flex: none;
+		min-width: 0;
+	}
+
+	.maplibregl-export-unit {
+		flex: none;
+		font-size: 12px;
+	}
 }
 
 /*


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

 - feat: add custom to PageSize menu to allow users to change height and width freely,
 - fix: fixed form layout collapse, make it look better.

<img width="297" height="258" alt="image" src="https://github.com/user-attachments/assets/de45703b-2803-4ef8-9a22-22daaabc08c6" />

<img width="240" height="287" alt="image" src="https://github.com/user-attachments/assets/e5d59de9-4ed8-484a-9459-73cfcb8c66f9" />

## Plugin

Select a plugin related to this PR.

- [x] maplibre-gl-export
- [x] mapbox-gl-export

## Type of Pull Request
<!-- ignore-task-list-start -->
- [x] Adding a feature
- [ ] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings
<!-- ignore-task-list-start -->
- [x] Code is up-to-date with the `main` branch
- [x] No lint errors after `pnpm lint`
- [x] Make sure all the existing features working well
- [x] Make sure a changeset file is added if your PR changes package code
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/watergis/maplibre-gl-export/tree/master/CONTRIBUTING.md) for more details.
