### PR TITLE
fix: remove duplicated text-align from the export list button style

### DIFF
--- a/.changeset/olive-pandas-clean.md
+++ b/.changeset/olive-pandas-clean.md
@@ -1,0 +1,6 @@
+---
+"@watergis/maplibre-gl-export": patch
+"@watergis/mapbox-gl-export": patch
+---
+
+fix: remove the duplicated `text-align` declaration from the export list button style. `text-align: right` was overridden by `text-align: center` on the next line, so only the dead declaration is dropped and the rendering is unchanged.

--- a/packages/mapbox-gl-export/src/scss/mapbox-gl-export.scss
+++ b/packages/mapbox-gl-export/src/scss/mapbox-gl-export.scss
@@ -24,7 +24,6 @@
 	display: block;
 	font-size: 14px;
 	padding: 8px 8px 6px;
-	text-align: right;
 	width: 100%;
 	height: auto;
 	text-align: center;

--- a/packages/maplibre-gl-export/src/scss/maplibre-gl-export.scss
+++ b/packages/maplibre-gl-export/src/scss/maplibre-gl-export.scss
@@ -24,7 +24,6 @@
 	display: block;
 	font-size: 14px;
 	padding: 8px 8px 6px;
-	text-align: right;
 	width: 100%;
 	height: auto;
 	text-align: center;


### PR DESCRIPTION
## Summary

`.maplibregl-export-list button` (and its mapbox counterpart) declared `text-align: right` and `text-align: center` in the same rule. The second declaration always wins, so the first one was dead code.

This removes the dead `text-align: right` declaration from both packages. The rendered result is unchanged.

## Test plan

- `pnpm lint` passes
- `pnpm build` produces the CSS with `text-align: center` only
- The export panel buttons keep their centered labels

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)