### PR TITLE
docs: document the .env setup required to run the demo site

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,15 @@ Note. Most of common features are imported from `maplibre-gl-export` plugin
 
 - Demo documentation
 
+The demo site shows both the maplibre and the mapbox plugin, so a Mapbox access token is
+required to run it locally. Copy `.env.example` and set your own token in it.
+
+```shell
+cd sites/demo
+cp .env.example .env
+# then set your Mapbox access token to PUBLIC_MAPBOX_ACCESSTOKEN in .env
+```
+
 ```shell
 # build maplibre-gl-export and mapbox-gl-export at the root folder of the repository
 pnpm build


### PR DESCRIPTION
## Summary

The demo site renders both the maplibre and the mapbox plugin, so it needs a Mapbox access token. `sites/demo/.env.example` already existed, but the step to copy it to `.env` was not documented in `CONTRIBUTING.md` or in any README, so `pnpm dev` failed for new contributors.

This adds the `cp .env.example .env` step and a note about `PUBLIC_MAPBOX_ACCESSTOKEN` to the "Demo documentation" section of `CONTRIBUTING.md`.

## Test plan

- Follow the documented steps from a clean checkout and confirm the demo site starts and both map pages render

Closes #420

🤖 Generated with [Claude Code](https://claude.com/claude-code)