### PR TITLE
fix: keep the style image metadata when copying images to the export map

### DIFF
--- a/.changeset/tall-pugs-repeat.md
+++ b/.changeset/tall-pugs-repeat.md
@@ -1,0 +1,6 @@
+---
+"@watergis/maplibre-gl-export": patch
+"@watergis/mapbox-gl-export": patch
+---
+
+fix: keep the metadata of the style images when they are copied to the map used for exporting. `pixelRatio`, `sdf`, `stretchX/Y` and `content` were dropped, so high resolution icons were exported at their full bitmap size and `icon-color` was no longer applied to SDF icons. The mapbox plugin additionally failed to copy any image at all, because mapbox-gl v3 keeps them in a nested `Map` instead of a plain object.

--- a/packages/mapbox-gl-export/index.ts
+++ b/packages/mapbox-gl-export/index.ts
@@ -28,32 +28,46 @@ map.addControl(
 new mapboxgl.Marker().setLngLat([37.30467, -0.15943]).addTo(map);
 
 /**
- * Draw a filled disc whose alpha fades towards the edge. It is used both as a plain high
- * resolution icon and as a (crude) SDF icon by the test layers below.
+ * Draw a thick ring with a white outline, which stands out on both light and dark imagery.
+ * Only the alpha channel is used when the image is added as an SDF icon, so the same shape
+ * works for both test icons.
+ * @param size length of a side of the bitmap in pixels
+ * @param color fill color of the ring. Ignored when the image is used as an SDF icon
  */
-const createIconImage = (size: number) => {
+const createIconImage = (size: number, color: string) => {
 	const canvas = document.createElement('canvas');
 	canvas.width = size;
 	canvas.height = size;
 	const ctx = canvas.getContext('2d');
 	if (!ctx) throw new Error('failed to get 2D context');
-	const gradient = ctx.createRadialGradient(size / 2, size / 2, 0, size / 2, size / 2, size / 2);
-	gradient.addColorStop(0, 'rgba(0, 0, 0, 1)');
-	gradient.addColorStop(1, 'rgba(0, 0, 0, 0)');
-	ctx.fillStyle = gradient;
-	ctx.fillRect(0, 0, size, size);
+	const center = size / 2;
+	const disc = (radius: number, fillStyle: string) => {
+		ctx.fillStyle = fillStyle;
+		ctx.beginPath();
+		ctx.arc(center, center, radius, 0, Math.PI * 2);
+		ctx.fill();
+	};
+	// white outline, then the ring itself
+	disc(size * 0.5, '#ffffff');
+	disc(size * 0.42, color);
+	// punch the middle out so the icon reads as a ring
+	ctx.globalCompositeOperation = 'destination-out';
+	disc(size * 0.2, '#000000');
 	return ctx.getImageData(0, 0, size, size);
 };
 
 /**
  * Test layers for https://github.com/watergis/maplibre-gl-export/issues/370. `high-res-icon`
- * is rendered at 1/4 of its bitmap size through `pixelRatio`, and `sdf-icon` is tinted through
- * `icon-color`. Both only work when the image metadata is kept while the images are copied to
- * the map used for exporting, so the exported image has to look the same as the map.
+ * is rendered at 1/4 of its bitmap size through `pixelRatio`, so it has to come out half as
+ * wide as `sdf-icon`, which is in turn tinted green through `icon-color`. Both only work when
+ * the image metadata is kept while the images are copied to the map used for exporting, so the
+ * exported image has to look the same as the map.
+ *
+ * They are placed next to the initial center of the map so they are visible without panning.
  */
 map.once('load', () => {
-	map.addImage('high-res-icon', createIconImage(128), { pixelRatio: 4 });
-	map.addImage('sdf-icon', createIconImage(64), { sdf: true });
+	map.addImage('high-res-icon', createIconImage(128, '#d63b3b'), { pixelRatio: 4 });
+	map.addImage('sdf-icon', createIconImage(64, '#000000'), { sdf: true });
 
 	map.addSource('test-icons', {
 		type: 'geojson',
@@ -63,21 +77,36 @@ map.once('load', () => {
 				{
 					type: 'Feature',
 					properties: { icon: 'high-res-icon' },
-					geometry: { type: 'Point', coordinates: [35.86063, -1.08551] }
+					geometry: { type: 'Point', coordinates: [35.85063, -1.08551] }
 				},
 				{
 					type: 'Feature',
 					properties: { icon: 'sdf-icon' },
-					geometry: { type: 'Point', coordinates: [35.88063, -1.08551] }
+					geometry: { type: 'Point', coordinates: [35.89063, -1.08551] }
 				}
 			]
 		}
 	});
 
+	// SDF and non-SDF icons cannot be mixed in one symbol layer: the layer takes the flag of
+	// the first icon it rasterizes, so `icon-color` would silently stop working. They get one
+	// layer each.
 	map.addLayer({
-		id: 'test-icons',
+		id: 'test-icons-high-res',
 		type: 'symbol',
 		source: 'test-icons',
+		filter: ['==', ['get', 'icon'], 'high-res-icon'],
+		layout: {
+			'icon-image': ['get', 'icon'],
+			'icon-allow-overlap': true
+		}
+	});
+
+	map.addLayer({
+		id: 'test-icons-sdf',
+		type: 'symbol',
+		source: 'test-icons',
+		filter: ['==', ['get', 'icon'], 'sdf-icon'],
 		layout: {
 			'icon-image': ['get', 'icon'],
 			'icon-allow-overlap': true

--- a/packages/mapbox-gl-export/index.ts
+++ b/packages/mapbox-gl-export/index.ts
@@ -26,3 +26,64 @@ map.addControl(
 );
 
 new mapboxgl.Marker().setLngLat([37.30467, -0.15943]).addTo(map);
+
+/**
+ * Draw a filled disc whose alpha fades towards the edge. It is used both as a plain high
+ * resolution icon and as a (crude) SDF icon by the test layers below.
+ */
+const createIconImage = (size: number) => {
+	const canvas = document.createElement('canvas');
+	canvas.width = size;
+	canvas.height = size;
+	const ctx = canvas.getContext('2d');
+	if (!ctx) throw new Error('failed to get 2D context');
+	const gradient = ctx.createRadialGradient(size / 2, size / 2, 0, size / 2, size / 2, size / 2);
+	gradient.addColorStop(0, 'rgba(0, 0, 0, 1)');
+	gradient.addColorStop(1, 'rgba(0, 0, 0, 0)');
+	ctx.fillStyle = gradient;
+	ctx.fillRect(0, 0, size, size);
+	return ctx.getImageData(0, 0, size, size);
+};
+
+/**
+ * Test layers for https://github.com/watergis/maplibre-gl-export/issues/370. `high-res-icon`
+ * is rendered at 1/4 of its bitmap size through `pixelRatio`, and `sdf-icon` is tinted through
+ * `icon-color`. Both only work when the image metadata is kept while the images are copied to
+ * the map used for exporting, so the exported image has to look the same as the map.
+ */
+map.once('load', () => {
+	map.addImage('high-res-icon', createIconImage(128), { pixelRatio: 4 });
+	map.addImage('sdf-icon', createIconImage(64), { sdf: true });
+
+	map.addSource('test-icons', {
+		type: 'geojson',
+		data: {
+			type: 'FeatureCollection',
+			features: [
+				{
+					type: 'Feature',
+					properties: { icon: 'high-res-icon' },
+					geometry: { type: 'Point', coordinates: [35.86063, -1.08551] }
+				},
+				{
+					type: 'Feature',
+					properties: { icon: 'sdf-icon' },
+					geometry: { type: 'Point', coordinates: [35.88063, -1.08551] }
+				}
+			]
+		}
+	});
+
+	map.addLayer({
+		id: 'test-icons',
+		type: 'symbol',
+		source: 'test-icons',
+		layout: {
+			'icon-image': ['get', 'icon'],
+			'icon-allow-overlap': true
+		},
+		paint: {
+			'icon-color': '#00b300'
+		}
+	});
+});

--- a/packages/mapbox-gl-export/src/lib/map-generator.ts
+++ b/packages/mapbox-gl-export/src/lib/map-generator.ts
@@ -16,6 +16,41 @@ export interface MapboxMapGeneratorConfig extends MapGeneratorConfig {
 	accessToken?: string;
 }
 
+/**
+ * Separator mapbox-gl uses to stringify an image id which belongs to an iconset
+ * (`ImageId.toString()` returns `name<US>iconsetId` in that case).
+ */
+const IMAGE_ID_SEPARATOR = '\x1f';
+
+/** Image of the style together with its metadata. `StyleImage` is not exported by mapbox-gl. */
+type StyleImageLike = {
+	data?: unknown;
+	pixelRatio?: number;
+	sdf?: boolean;
+	stretchX?: [number, number][];
+	stretchY?: [number, number][];
+	content?: [number, number, number, number];
+};
+
+/**
+ * Read the images of the style out of the internal image manager.
+ *
+ * mapbox-gl v3 keeps them in a `Map<scope, Map<stringifiedImageId, StyleImage>>`, while
+ * older versions used a plain `{ [id: string]: StyleImage }` object. Both shapes are
+ * flattened into `[id, image]` pairs.
+ */
+const getStyleImageEntries = (images: unknown): [string, StyleImageLike][] => {
+	if (images instanceof Map) {
+		return [...images.values()].flatMap((scoped) =>
+			scoped instanceof Map ? ([...scoped.entries()] as [string, StyleImageLike][]) : []
+		);
+	}
+	if (images && typeof images === 'object') {
+		return Object.entries(images as Record<string, StyleImageLike>);
+	}
+	return [];
+};
+
 export default class MapGenerator extends MapGeneratorBase {
 	private accesstoken: string | undefined;
 
@@ -81,18 +116,18 @@ export default class MapGenerator extends MapGeneratorBase {
 		// eslint-disable-next-line
 		// @ts-ignore
 		const imageManager = this.map.style.imageManager;
-		const images =
-			((imageManager as unknown as Record<string, unknown>)?.images as Record<
-				string,
-				{ data: unknown }
-			>) ?? {};
-		if (images && Object.keys(images)?.length > 0) {
-			Object.keys(images).forEach((key) => {
-				if (!key) return;
-				if (!images[key].data) return;
-				renderMap.addImage(key, images[key].data as ImageBitmap);
-			});
-		}
+		const images = (imageManager as unknown as Record<string, unknown>)?.images;
+		getStyleImageEntries(images).forEach(([key, image]) => {
+			// the id of an image belonging to an iconset is stringified as `name<US>iconsetId`.
+			// `addImage` only accepts the name.
+			const id = key.split(IMAGE_ID_SEPARATOR)[0];
+			if (!id || !image?.data) return;
+			// `StyleImage` is `StyleImageData & StyleImageMetadata`, so the image itself carries
+			// `pixelRatio`, `sdf`, `stretchX/Y`, `content` and so on. They have to be passed on,
+			// otherwise `pixelRatio` falls back to 1 (high resolution icons are exported at their
+			// full size) and `sdf` is lost (`icon-color` stops being applied).
+			renderMap.addImage(id, image.data as ImageBitmap, image);
+		});
 
 		this.addScaleControl(renderMap, this.scalebarOptions);
 		this.addAttributionControl(renderMap, this.attributionOptions);

--- a/packages/maplibre-gl-export/index.ts
+++ b/packages/maplibre-gl-export/index.ts
@@ -64,8 +64,71 @@ map.addControl(
 // @ts-ignore
 window.__map = map;
 
+/**
+ * Draw a filled disc whose alpha fades towards the edge. It is used both as a plain high
+ * resolution icon and as a (crude) SDF icon by the test layers below.
+ */
+const createIconImage = (size: number) => {
+	const canvas = document.createElement('canvas');
+	canvas.width = size;
+	canvas.height = size;
+	const ctx = canvas.getContext('2d');
+	if (!ctx) throw new Error('failed to get 2D context');
+	const gradient = ctx.createRadialGradient(size / 2, size / 2, 0, size / 2, size / 2, size / 2);
+	gradient.addColorStop(0, 'rgba(0, 0, 0, 1)');
+	gradient.addColorStop(1, 'rgba(0, 0, 0, 0)');
+	ctx.fillStyle = gradient;
+	ctx.fillRect(0, 0, size, size);
+	return ctx.getImageData(0, 0, size, size);
+};
+
+/**
+ * Test layers for https://github.com/watergis/maplibre-gl-export/issues/370. `high-res-icon`
+ * is rendered at 1/4 of its bitmap size through `pixelRatio`, and `sdf-icon` is tinted through
+ * `icon-color`. Both only work when the image metadata is kept while the images are copied to
+ * the map used for exporting, so the exported image has to look the same as the map.
+ */
+const addTestIcons = () => {
+	map.addImage('high-res-icon', createIconImage(128), { pixelRatio: 4 });
+	map.addImage('sdf-icon', createIconImage(64), { sdf: true });
+
+	map.addSource('test-icons', {
+		type: 'geojson',
+		data: {
+			type: 'FeatureCollection',
+			features: [
+				{
+					type: 'Feature',
+					properties: { icon: 'high-res-icon' },
+					geometry: { type: 'Point', coordinates: [37.29467, -0.15943] }
+				},
+				{
+					type: 'Feature',
+					properties: { icon: 'sdf-icon' },
+					geometry: { type: 'Point', coordinates: [37.31467, -0.15943] }
+				}
+			]
+		}
+	});
+
+	map.addLayer({
+		id: 'test-icons',
+		type: 'symbol',
+		source: 'test-icons',
+		layout: {
+			'icon-image': ['get', 'icon'],
+			'icon-allow-overlap': true
+		},
+		paint: {
+			'icon-color': '#00b300'
+		}
+	});
+};
+
 map.once('load', () => {
 	new Marker().setLngLat([37.30467, -0.15943]).addTo(map);
+
+	addTestIcons();
 
 	if (map.getSource('terrarium')) {
 		map.addControl(

--- a/packages/maplibre-gl-export/index.ts
+++ b/packages/maplibre-gl-export/index.ts
@@ -65,32 +65,46 @@ map.addControl(
 window.__map = map;
 
 /**
- * Draw a filled disc whose alpha fades towards the edge. It is used both as a plain high
- * resolution icon and as a (crude) SDF icon by the test layers below.
+ * Draw a thick ring with a white outline, which stands out on both light and dark imagery.
+ * Only the alpha channel is used when the image is added as an SDF icon, so the same shape
+ * works for both test icons.
+ * @param size length of a side of the bitmap in pixels
+ * @param color fill color of the ring. Ignored when the image is used as an SDF icon
  */
-const createIconImage = (size: number) => {
+const createIconImage = (size: number, color: string) => {
 	const canvas = document.createElement('canvas');
 	canvas.width = size;
 	canvas.height = size;
 	const ctx = canvas.getContext('2d');
 	if (!ctx) throw new Error('failed to get 2D context');
-	const gradient = ctx.createRadialGradient(size / 2, size / 2, 0, size / 2, size / 2, size / 2);
-	gradient.addColorStop(0, 'rgba(0, 0, 0, 1)');
-	gradient.addColorStop(1, 'rgba(0, 0, 0, 0)');
-	ctx.fillStyle = gradient;
-	ctx.fillRect(0, 0, size, size);
+	const center = size / 2;
+	const disc = (radius: number, fillStyle: string) => {
+		ctx.fillStyle = fillStyle;
+		ctx.beginPath();
+		ctx.arc(center, center, radius, 0, Math.PI * 2);
+		ctx.fill();
+	};
+	// white outline, then the ring itself
+	disc(size * 0.5, '#ffffff');
+	disc(size * 0.42, color);
+	// punch the middle out so the icon reads as a ring
+	ctx.globalCompositeOperation = 'destination-out';
+	disc(size * 0.2, '#000000');
 	return ctx.getImageData(0, 0, size, size);
 };
 
 /**
  * Test layers for https://github.com/watergis/maplibre-gl-export/issues/370. `high-res-icon`
- * is rendered at 1/4 of its bitmap size through `pixelRatio`, and `sdf-icon` is tinted through
- * `icon-color`. Both only work when the image metadata is kept while the images are copied to
- * the map used for exporting, so the exported image has to look the same as the map.
+ * is rendered at 1/4 of its bitmap size through `pixelRatio`, so it has to come out half as
+ * wide as `sdf-icon`, which is in turn tinted green through `icon-color`. Both only work when
+ * the image metadata is kept while the images are copied to the map used for exporting, so the
+ * exported image has to look the same as the map.
+ *
+ * They are placed next to the initial center of the map so they are visible without panning.
  */
 const addTestIcons = () => {
-	map.addImage('high-res-icon', createIconImage(128), { pixelRatio: 4 });
-	map.addImage('sdf-icon', createIconImage(64), { sdf: true });
+	map.addImage('high-res-icon', createIconImage(128, '#d63b3b'), { pixelRatio: 4 });
+	map.addImage('sdf-icon', createIconImage(64, '#000000'), { sdf: true });
 
 	map.addSource('test-icons', {
 		type: 'geojson',
@@ -100,21 +114,36 @@ const addTestIcons = () => {
 				{
 					type: 'Feature',
 					properties: { icon: 'high-res-icon' },
-					geometry: { type: 'Point', coordinates: [37.29467, -0.15943] }
+					geometry: { type: 'Point', coordinates: [-25, 0] }
 				},
 				{
 					type: 'Feature',
 					properties: { icon: 'sdf-icon' },
-					geometry: { type: 'Point', coordinates: [37.31467, -0.15943] }
+					geometry: { type: 'Point', coordinates: [25, 0] }
 				}
 			]
 		}
 	});
 
+	// SDF and non-SDF icons cannot be mixed in one symbol layer: the layer takes the flag of
+	// the first icon it rasterizes, so `icon-color` would silently stop working. They get one
+	// layer each.
 	map.addLayer({
-		id: 'test-icons',
+		id: 'test-icons-high-res',
 		type: 'symbol',
 		source: 'test-icons',
+		filter: ['==', ['get', 'icon'], 'high-res-icon'],
+		layout: {
+			'icon-image': ['get', 'icon'],
+			'icon-allow-overlap': true
+		}
+	});
+
+	map.addLayer({
+		id: 'test-icons-sdf',
+		type: 'symbol',
+		source: 'test-icons',
+		filter: ['==', ['get', 'icon'], 'sdf-icon'],
 		layout: {
 			'icon-image': ['get', 'icon'],
 			'icon-allow-overlap': true

--- a/packages/maplibre-gl-export/src/lib/map-generator.ts
+++ b/packages/maplibre-gl-export/src/lib/map-generator.ts
@@ -50,8 +50,13 @@ export default class MapGenerator extends MapGeneratorBase {
 		// the below code was added by https://github.com/watergis/maplibre-gl-export/pull/18.
 		const images = ((this.map as MaplibreMap).style.imageManager || {}).images || [];
 		Object.keys(images).forEach((key) => {
-			if (!images[key].data) return;
-			renderMap.addImage(key, images[key].data);
+			const image = images[key];
+			if (!image?.data) return;
+			// `StyleImage` is `StyleImageData & StyleImageMetadata`, so the image itself carries
+			// `pixelRatio`, `sdf`, `stretchX/Y`, `content` and so on. They have to be passed on,
+			// otherwise `pixelRatio` falls back to 1 (high resolution icons are exported at their
+			// full size) and `sdf` is lost (`icon-color` stops being applied).
+			renderMap.addImage(key, image.data, image);
 		});
 
 		this.addScaleControl(renderMap, this.scalebarOptions);


### PR DESCRIPTION
## Summary

The images of the style were copied to the hidden map used for exporting with `addImage(id, image.data)`, which dropped everything but the pixels.

`StyleImage` is `StyleImageData & StyleImageMetadata`, so the image object itself carries `pixelRatio`, `sdf`, `stretchX` / `stretchY` and `content`. Because they were not passed on:

- `pixelRatio` fell back to `1`, so a high resolution icon (e.g. a 128px bitmap added with `pixelRatio: 4`) was exported at its full bitmap size instead of the size it has on the map — the "comically large" icons of #370.
- `sdf` was lost, so `icon-color` was no longer applied to SDF icons.

The image is now passed as the metadata argument of `addImage`.

While fixing this, a second bug showed up on the mapbox side: mapbox-gl v3 keeps the images in a `Map<scope, Map<stringifiedImageId, StyleImage>>`, while the code still assumed a plain `{ [id]: StyleImage }` object. `Object.keys()` on a `Map` returns nothing, so **no image at all** was copied to the export map. Both shapes are handled now, and the id is un-stringified for images belonging to an iconset.

This also covers what #421 was trying to fix, so that PR can be closed.

## Test plan

Test layers with a high resolution icon (`pixelRatio: 4`) and an SDF icon (`icon-color`) were added to the demo pages of both packages.

Verified against the maplibre demo with a 128px icon added as `pixelRatio: 4` and a 64px SDF icon, exported as PNG at A6/96 DPI:

| icon | size on the map | size in the export (before) | size in the export (after) |
| --- | --- | --- | --- |
| high resolution (128px, `pixelRatio: 4`) | 32px | 128px | **32px** |
| SDF (64px) | 64px | 64px | 64px |

Closes #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)