### PR TITLE
feat: expose the generated image instead of only downloading it

### DIFF
--- a/.changeset/khaki-jokes-shake.md
+++ b/.changeset/khaki-jokes-shake.md
@@ -3,4 +3,35 @@
 "@watergis/mapbox-gl-export": minor
 ---
 
-feat: make the generated image available to the application instead of only downloading it. `MapGenerator` now exposes `toCanvas()` and `toBlob()`, and both the generator and the export control accept a `download` option and an `onExport` callback which receives `{ canvas, blob, fileName, format }`. `MapGenerator` is exported from both packages.
+feat: make the generated image available to the application instead of only downloading it.
+
+`MapGenerator` is now exported from both packages and exposes `toCanvas()` and `toBlob()`, so the image can be generated without the export panel and without saving a file:
+
+```ts
+import { MapGenerator, Format, Size } from '@watergis/maplibre-gl-export';
+
+// composed canvas of the map, at the requested page size and DPI
+const canvas = await new MapGenerator(map, { size: Size.A4, dpi: 300 }).toCanvas();
+
+// or the image in the configured format. png, jpg, pdf and svg are supported
+const blob = await new MapGenerator(map, { size: Size.A4, format: Format.PDF }).toBlob();
+setPdfUrl(URL.createObjectURL(blob));
+```
+
+The generator and the export control also accept a `download` option and an `onExport` callback, so the image produced by the generate button of the panel can be picked up by the application. `download` defaults to `true`, so the file keeps being saved unless it is turned off:
+
+```ts
+map.addControl(
+  new MaplibreExportControl({
+    PageSize: Size.A4,
+    Format: Format.PNG,
+    // do not save the image as a file, only hand it over to `onExport`
+    download: false,
+    onExport: ({ canvas, blob, fileName, format }) => {
+      console.log(`generated ${fileName} (${format}), ${blob.size} bytes`);
+      setImageUrl(URL.createObjectURL(blob));
+    }
+  }),
+  'top-right'
+);
+```

--- a/.changeset/khaki-jokes-shake.md
+++ b/.changeset/khaki-jokes-shake.md
@@ -1,0 +1,6 @@
+---
+"@watergis/maplibre-gl-export": minor
+"@watergis/mapbox-gl-export": minor
+---
+
+feat: make the generated image available to the application instead of only downloading it. `MapGenerator` now exposes `toCanvas()` and `toBlob()`, and both the generator and the export control accept a `download` option and an `onExport` callback which receives `{ canvas, blob, fileName, format }`. `MapGenerator` is exported from both packages.

--- a/packages/mapbox-gl-export/src/lib/export-control.ts
+++ b/packages/mapbox-gl-export/src/lib/export-control.ts
@@ -45,6 +45,8 @@ export default class MapboxExportControl extends MaplibreExportControl implement
 			attributionOptions: this.options.attributionOptions,
 			scalebarOptions: this.options.scalebarOptions,
 			northIconOptions: this.options.northIconOptions,
+			download: this.options.download,
+			onExport: this.options.onExport,
 			accessToken: this.accessToken
 		});
 		mapGenerator.generate();

--- a/packages/mapbox-gl-export/src/lib/index.ts
+++ b/packages/mapbox-gl-export/src/lib/index.ts
@@ -1,3 +1,4 @@
 export { default as MapboxExportControl } from './export-control';
+export { default as MapGenerator, type MapboxMapGeneratorConfig } from './map-generator';
 export { Size, PageOrientation, Format, DPI, type Language } from '@watergis/maplibre-gl-export';
 export * from './interfaces';

--- a/packages/maplibre-gl-export/src/lib/export-control.ts
+++ b/packages/maplibre-gl-export/src/lib/export-control.ts
@@ -295,7 +295,9 @@ export default class MaplibreExportControl implements IControl {
 			markerCirclePaint: this.options.markerCirclePaint,
 			attributionOptions: this.options.attributionOptions,
 			scalebarOptions: this.options.scalebarOptions,
-			northIconOptions: this.options.northIconOptions
+			northIconOptions: this.options.northIconOptions,
+			download: this.options.download,
+			onExport: this.options.onExport
 		});
 		mapGenerator.generate();
 	}

--- a/packages/maplibre-gl-export/src/lib/index.ts
+++ b/packages/maplibre-gl-export/src/lib/index.ts
@@ -1,4 +1,5 @@
 export { default as MaplibreExportControl } from './export-control';
+export { default as MapGenerator } from './map-generator';
 export { default as CrosshairManager } from './crosshair-manager';
 export { default as PrintableAreaManager } from './printable-area-manager';
 

--- a/packages/maplibre-gl-export/src/lib/interfaces/ControlOptions.ts
+++ b/packages/maplibre-gl-export/src/lib/interfaces/ControlOptions.ts
@@ -5,6 +5,7 @@ import { Language } from './Language';
 import { PageOrientationType } from './PageOrientation';
 import { AllowedSize, SizeType } from './Size';
 import { AttributionOptions } from './AttributionStyle';
+import { ExportResult } from './ExportResult';
 import { ScalebarOptions } from './ScalebarOptions';
 
 export interface NorthIconOptions {
@@ -36,4 +37,11 @@ export interface ControlOptions {
 	attributionOptions?: AttributionOptions;
 	scalebarOptions?: ScalebarOptions;
 	northIconOptions?: NorthIconOptions;
+	/** whether the exported image is downloaded as a file. default is true */
+	download?: boolean;
+	/**
+	 * Called with the exported image once the generate button has produced it. Use it to pass
+	 * the image on to the rest of the application instead of (or in addition to) downloading it.
+	 */
+	onExport?: (result: ExportResult) => void | Promise<void>;
 }

--- a/packages/maplibre-gl-export/src/lib/interfaces/ExportResult.ts
+++ b/packages/maplibre-gl-export/src/lib/interfaces/ExportResult.ts
@@ -1,0 +1,13 @@
+import { FormatType } from './Format';
+
+/** Exported image, handed to the `onExport` callback */
+export interface ExportResult {
+	/** composed image of the map. It is discarded once the callback has returned */
+	canvas: HTMLCanvasElement;
+	/** exported image in the requested format */
+	blob: Blob;
+	/** file name the image would be saved as, including the extension */
+	fileName: string;
+	/** format the image was exported in */
+	format: FormatType;
+}

--- a/packages/maplibre-gl-export/src/lib/interfaces/index.ts
+++ b/packages/maplibre-gl-export/src/lib/interfaces/index.ts
@@ -1,6 +1,7 @@
 export * from './AttributionStyle';
 export * from './ControlOptions';
 export * from './DPI';
+export * from './ExportResult';
 export * from './Format';
 export * from './Language';
 export * from './PageOrientation';

--- a/packages/maplibre-gl-export/src/lib/map-generator-base.ts
+++ b/packages/maplibre-gl-export/src/lib/map-generator-base.ts
@@ -35,6 +35,7 @@ import { CirclePaint, Map as MapboxMap } from 'mapbox-gl';
 import {
 	AttributionOptions,
 	DPIType,
+	ExportResult,
 	Format,
 	FormatType,
 	NorthIconOptions,
@@ -98,6 +99,13 @@ export interface MapGeneratorConfig {
 	attributionOptions?: AttributionOptions;
 	scalebarOptions?: ScalebarOptions;
 	northIconOptions?: NorthIconOptions;
+	/** whether the exported image is downloaded as a file. default is true */
+	download?: boolean;
+	/**
+	 * Called with the exported image once it has been generated. Use it to pass the image on
+	 * to the rest of the application instead of (or in addition to) downloading it.
+	 */
+	onExport?: (result: ExportResult) => void | Promise<void>;
 }
 
 /** Timeout for waiting the `load` event of the hidden map */
@@ -131,6 +139,10 @@ export abstract class MapGeneratorBase {
 
 	protected northIconOptions: NorthIconOptions;
 
+	protected download: boolean;
+
+	protected onExport: ((result: ExportResult) => void | Promise<void>) | undefined;
+
 	/** Hidden container holding the map used for rendering. Available while generating. */
 	protected hiddenContainer: HTMLElement | undefined;
 
@@ -153,6 +165,8 @@ export abstract class MapGeneratorBase {
 		this.attributionOptions = { ...defaultAttributionOptions, ...config.attributionOptions };
 		this.scalebarOptions = { ...defaultScalebarOptions, ...config.scalebarOptions };
 		this.northIconOptions = { ...defaultNorthIconOptions, ...config.northIconOptions };
+		this.download = config.download ?? true;
+		this.onExport = config.onExport;
 	}
 
 	/** Class name of markers of the underlying library */
@@ -241,13 +255,64 @@ export abstract class MapGeneratorBase {
 	}
 
 	/**
-	 * Generate and download Map image.
+	 * Generate the Map image, then download it and/or hand it to the `onExport` callback.
 	 *
 	 * The map is rendered on a hidden map object at the requested page size and DPI,
 	 * then its canvas is composed with the scale bar, north icon and attribution
 	 * onto a 2D canvas which is what actually gets exported.
 	 */
 	async generate() {
+		try {
+			await this.withRenderedMap(async (renderMap) => {
+				const canvas = await this.composeCanvas(renderMap);
+				if (this.download) {
+					this.exportImage(canvas, renderMap);
+				}
+				if (this.onExport) {
+					const blob = await this.toBlobOfFormat(canvas);
+					await this.onExport({
+						canvas,
+						blob,
+						fileName: `${this.fileName}.${this.format}`,
+						format: this.format
+					});
+				}
+			});
+		} catch (err) {
+			// `generate` is called from the export button, so there is nobody to hand the
+			// error to. `toCanvas` / `toBlob` let the caller handle it instead.
+			console.error('Failed to generate map image:', err);
+		}
+	}
+
+	/**
+	 * Generate the Map image and return it as a canvas instead of downloading it.
+	 *
+	 * The canvas holds the composed image at the requested page size and DPI, exactly as it
+	 * would be written to the exported file.
+	 */
+	async toCanvas() {
+		return this.withRenderedMap((renderMap) => this.composeCanvas(renderMap));
+	}
+
+	/**
+	 * Generate the Map image and return it as a `Blob` in the configured format instead of
+	 * downloading it. PDF and SVG are wrapped around the rendered image just like the
+	 * downloaded file is.
+	 */
+	async toBlob() {
+		const canvas = await this.toCanvas();
+		return this.toBlobOfFormat(canvas);
+	}
+
+	/**
+	 * Render the map on a hidden map object and run `fn` on it once it has finished rendering.
+	 *
+	 * The loader of the source map is shown while rendering, `window.devicePixelRatio` is
+	 * temporarily raised to the export scale factor so that the map is rendered at the
+	 * requested DPI, and everything is cleaned up again afterwards.
+	 */
+	private async withRenderedMap<T>(fn: (renderMap: MaplibreMap) => T | Promise<T>) {
 		this.addLoader();
 		this.showLoader();
 
@@ -295,12 +360,11 @@ export abstract class MapGeneratorBase {
 
 			await this.waitForEvent(renderMap, 'idle', IDLE_TIMEOUT_MS);
 
-			const canvas = await this.composeCanvas(renderMap);
-			this.exportImage(canvas, renderMap);
+			const result = await fn(renderMap);
 
 			renderMap.remove();
-		} catch (err) {
-			console.error('Failed to generate map image:', err);
+
+			return result;
 		} finally {
 			hidden.parentNode?.removeChild(hidden);
 			hidden.remove();
@@ -583,6 +647,15 @@ export abstract class MapGeneratorBase {
 	 * @param fileName file name
 	 */
 	private toPDF(canvas: HTMLCanvasElement, map: MaplibreMap | MapboxMap, fileName: string) {
+		this.createPDF(canvas, map).save(fileName);
+	}
+
+	/**
+	 * Wrap the composed canvas in a PDF document of the configured page size.
+	 * @param canvas composed Canvas element
+	 * @param map Map object used to read the document properties
+	 */
+	private createPDF(canvas: HTMLCanvasElement, map: MaplibreMap | MapboxMap) {
 		const pdf = new jsPDF({
 			orientation: this.width > this.height ? 'l' : 'p',
 			unit: this.unit,
@@ -609,7 +682,7 @@ export abstract class MapGeneratorBase {
 			author: '(c)Mapbox, (c)OpenStreetMap'
 		});
 
-		pdf.save(fileName);
+		return pdf;
 	}
 
 	/**
@@ -618,6 +691,18 @@ export abstract class MapGeneratorBase {
 	 * @param fileName file name
 	 */
 	private toSVG(canvas: HTMLCanvasElement, fileName: string) {
+		const a = document.createElement('a');
+		a.href = `data:application/xml,${encodeURIComponent(this.createSVG(canvas))}`;
+		a.download = fileName;
+		a.click();
+		a.remove();
+	}
+
+	/**
+	 * Wrap the composed canvas in an SVG document of the configured page size.
+	 * @param canvas Canvas element
+	 */
+	private createSVG(canvas: HTMLCanvasElement) {
 		const uri = canvas.toDataURL('image/png');
 
 		const pxWidth = Number(this.toPixels(this.width, this.dpi).replace('px', ''));
@@ -635,11 +720,42 @@ export abstract class MapGeneratorBase {
       xlink:href="${uri}" width="${pxWidth}" height="${pxHeight}"></image>
     </svg>`;
 
-		const a = document.createElement('a');
-		a.href = `data:application/xml,${encodeURIComponent(svg)}`;
-		a.download = fileName;
-		a.click();
-		a.remove();
+		return svg;
+	}
+
+	/**
+	 * Convert the composed canvas into a `Blob` of the configured format.
+	 * @param canvas composed Canvas element
+	 */
+	private async toBlobOfFormat(canvas: HTMLCanvasElement): Promise<Blob> {
+		switch (this.format) {
+			case Format.JPEG:
+				return this.canvasToBlob(canvas, 'image/jpeg', 0.85);
+			case Format.PDF:
+				// the source map is used for the document properties. The map which was rendered
+				// shares its center, zoom and style, and it is already removed at this point.
+				return this.createPDF(canvas, this.map).output('blob');
+			case Format.SVG:
+				return new Blob([this.createSVG(canvas)], { type: 'image/svg+xml' });
+			case Format.PNG:
+				return this.canvasToBlob(canvas, 'image/png');
+			default:
+				throw new Error(`Invalid file format: ${this.format}`);
+		}
+	}
+
+	/** Promisified `HTMLCanvasElement.toBlob` */
+	private canvasToBlob(canvas: HTMLCanvasElement, type: string, quality?: number) {
+		return new Promise<Blob>((resolve, reject) => {
+			canvas.toBlob(
+				(blob) => {
+					if (blob) resolve(blob);
+					else reject(new Error(`Failed to convert the map image to ${type}`));
+				},
+				type,
+				quality
+			);
+		});
 	}
 
 	/**

--- a/sites/demo/src/routes/+page.svelte
+++ b/sites/demo/src/routes/+page.svelte
@@ -188,6 +188,18 @@
 				'North icon options. It is drawn onto the exported image at the top-right corner as default, rotated to match the map bearing. The size of north icon is 5% of map width. You can customize icon image and other settings through this option. It can also be toggled from the export panel.'
 		},
 		{
+			name: 'download',
+			default: 'true',
+			description:
+				'Whether the generated image is downloaded as a file. Set it to `false` when you only want to receive the image through `onExport`.'
+		},
+		{
+			name: 'onExport',
+			default: 'undefined',
+			description:
+				'Callback which receives the generated image, so it can be passed on to the rest of your application instead of (or in addition to) being downloaded. It is called with `{ canvas, blob, fileName, format }`. e.g. `onExport: ({ blob }) => setImageUrl(URL.createObjectURL(blob))`. The exported image can also be generated without the export panel by using `MapGenerator` directly: `await new MapGenerator(map, { size: Size.A4 }).toBlob()`.'
+		},
+		{
 			name: 'accessToken',
 			default: 'mapboxgl.accessToken is used as default',
 			description: 'Mapbox access token is required'

--- a/sites/demo/src/routes/mapbox/+page.svelte
+++ b/sites/demo/src/routes/mapbox/+page.svelte
@@ -20,12 +20,25 @@
 	let mapContainer: HTMLDivElement | undefined = $state();
 
 	let exportControl: MapboxExportControl;
+	let onExportControl: MapboxExportControl;
+
+	let exportedImage: { url: string; fileName: string; format: string; size: number } | undefined =
+		$state();
+
+	const clearExportedImage = () => {
+		if (!exportedImage) return;
+		URL.revokeObjectURL(exportedImage.url);
+		exportedImage = undefined;
+	};
 
 	const initExportControl = () => {
 		if (!map) return;
 		if (!language) return;
 		if (exportControl) {
 			map.removeControl(exportControl);
+		}
+		if (onExportControl) {
+			map.removeControl(onExportControl);
 		}
 
 		exportControl = new MapboxExportControl({
@@ -45,6 +58,29 @@
 		});
 
 		map.addControl(exportControl, 'top-right');
+
+		// second control to test `onExport`. The image is not downloaded, it is shown in the panel below instead.
+		onExportControl = new MapboxExportControl({
+			PageSize: Size.A4,
+			PageOrientation: PageOrientation.Landscape,
+			Format: Format.PNG,
+			DPI: DPI[96],
+			Crosshair: true,
+			PrintableArea: true,
+			Local: language,
+			download: false,
+			onExport: ({ blob, fileName, format }) => {
+				clearExportedImage();
+				exportedImage = {
+					url: URL.createObjectURL(blob),
+					fileName,
+					format,
+					size: blob.size
+				};
+			}
+		});
+
+		map.addControl(onExportControl, 'top-left');
 	};
 
 	onMount(() => {
@@ -80,10 +116,66 @@
 	<LanguageSelector {map} bind:language position="bottom-left" change={onLanguageChange} />
 {/if}
 
+{#if exportedImage}
+	<div class="export-result">
+		<div class="export-result-header">
+			<span>onExport result</span>
+			<button type="button" onclick={clearExportedImage} aria-label="close">✕</button>
+		</div>
+		<img src={exportedImage.url} alt="exported map" />
+		<div class="export-result-meta">
+			<div>{exportedImage.fileName}</div>
+			<div>{exportedImage.format} / {(exportedImage.size / 1024).toFixed(1)} KB</div>
+		</div>
+	</div>
+{/if}
+
 <style lang="scss">
 	.map {
 		position: relative;
 		width: 100%;
 		height: 100%;
+	}
+
+	.export-result {
+		position: absolute;
+		bottom: 30px;
+		left: 200px;
+		z-index: 10;
+		width: 260px;
+		padding: 8px;
+		border-radius: 4px;
+		background: #fff;
+		color: #000;
+		box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
+
+		.export-result-header {
+			display: flex;
+			align-items: center;
+			justify-content: space-between;
+			font-weight: bold;
+			margin-bottom: 6px;
+
+			button {
+				border: none;
+				background: none;
+				cursor: pointer;
+				font-size: 14px;
+				line-height: 1;
+			}
+		}
+
+		img {
+			display: block;
+			width: 100%;
+			height: auto;
+			border: 1px solid #ccc;
+		}
+
+		.export-result-meta {
+			margin-top: 6px;
+			font-size: 12px;
+			word-break: break-all;
+		}
 	}
 </style>

--- a/sites/demo/src/routes/maplibre/+page.svelte
+++ b/sites/demo/src/routes/maplibre/+page.svelte
@@ -29,14 +29,27 @@
 	let mapContainer: HTMLDivElement | undefined = $state();
 
 	let exportControl: MaplibreExportControl;
+	let onExportControl: MaplibreExportControl;
+
+	let exportedImage: { url: string; fileName: string; format: string; size: number } | undefined =
+		$state();
 
 	setWorkerUrl(workerUrl);
+
+	const clearExportedImage = () => {
+		if (!exportedImage) return;
+		URL.revokeObjectURL(exportedImage.url);
+		exportedImage = undefined;
+	};
 
 	const initExportControl = () => {
 		if (!map) return;
 		if (!language) return;
 		if (exportControl) {
 			map.removeControl(exportControl);
+		}
+		if (onExportControl) {
+			map.removeControl(onExportControl);
 		}
 
 		exportControl = new MaplibreExportControl({
@@ -56,6 +69,29 @@
 		});
 
 		map.addControl(exportControl, 'top-right');
+
+		// second control to test `onExport`. The image is not downloaded, it is shown in the panel below instead.
+		onExportControl = new MaplibreExportControl({
+			PageSize: Size.A4,
+			PageOrientation: PageOrientation.Landscape,
+			Format: Format.PNG,
+			DPI: DPI[96],
+			Crosshair: true,
+			PrintableArea: true,
+			Local: language,
+			download: false,
+			onExport: ({ blob, fileName, format }) => {
+				clearExportedImage();
+				exportedImage = {
+					url: URL.createObjectURL(blob),
+					fileName,
+					format,
+					size: blob.size
+				};
+			}
+		});
+
+		map.addControl(onExportControl, 'top-left');
 	};
 
 	onMount(() => {
@@ -111,10 +147,66 @@
 	<LanguageSelector {map} bind:language position="bottom-left" change={onLanguageChange} />
 {/if}
 
+{#if exportedImage}
+	<div class="export-result">
+		<div class="export-result-header">
+			<span>onExport result</span>
+			<button type="button" onclick={clearExportedImage} aria-label="close">✕</button>
+		</div>
+		<img src={exportedImage.url} alt="exported map" />
+		<div class="export-result-meta">
+			<div>{exportedImage.fileName}</div>
+			<div>{exportedImage.format} / {(exportedImage.size / 1024).toFixed(1)} KB</div>
+		</div>
+	</div>
+{/if}
+
 <style lang="scss">
 	.map {
 		position: relative;
 		width: 100%;
 		height: 100%;
+	}
+
+	.export-result {
+		position: absolute;
+		bottom: 30px;
+		left: 200px;
+		z-index: 10;
+		width: 260px;
+		padding: 8px;
+		border-radius: 4px;
+		background: #fff;
+		color: #000;
+		box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
+
+		.export-result-header {
+			display: flex;
+			align-items: center;
+			justify-content: space-between;
+			font-weight: bold;
+			margin-bottom: 6px;
+
+			button {
+				border: none;
+				background: none;
+				cursor: pointer;
+				font-size: 14px;
+				line-height: 1;
+			}
+		}
+
+		img {
+			display: block;
+			width: 100%;
+			height: auto;
+			border: 1px solid #ccc;
+		}
+
+		.export-result-meta {
+			margin-top: 6px;
+			font-size: 12px;
+			word-break: break-all;
+		}
 	}
 </style>


### PR DESCRIPTION
## Summary

`generate()` rendered the map, composed the image and saved it as a file in one go, so there was no way to get hold of the generated image and pass it on to the rest of the application — which is what #48 asks for.

The rendering is now separated from the saving through a private `withRenderedMap()` helper (it holds the loader handling, the `devicePixelRatio` override, the hidden container and the cleanup that `generate()` used to do inline), and three ways to receive the image are added:

```ts
// without the control
const canvas = await new MapGenerator(map, { size: Size.A4 }).toCanvas();
const blob = await new MapGenerator(map, { size: Size.A4, format: Format.PDF }).toBlob();

// from the export panel
new MaplibreExportControl({
  download: false, // optional, the file is still downloaded by default
  onExport: ({ canvas, blob, fileName, format }) => setImageUrl(URL.createObjectURL(blob))
});
```

`MapGenerator` is now exported from both packages so it can be used directly.

Behaviour that did not change: `generate()` still downloads the file by default and still swallows errors, since it is called from the export button. `toCanvas()` / `toBlob()` reject instead, so the caller can handle the failure.

## Test plan

Verified against a map in the maplibre dev page, exporting A6 at 96 DPI:

| call | result |
| --- | --- |
| `toCanvas()` | 559x397 canvas containing the map, 0 downloads |
| `toBlob()` png / jpg / pdf / svg | `image/png`, `image/jpeg`, `application/pdf`, `image/svg+xml` blobs, 0 downloads |
| `generate()` with `download: false` + `onExport` | callback got `{ fileName: 'mymap.png', format: 'png', blob: image/png, canvas: 559px }`, 0 downloads |
| `generate()` with the defaults | 1 download, as before |

The two new options are documented in the options table of the demo site.

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)